### PR TITLE
feat: configurable sliding window trajectory length

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -224,6 +224,7 @@ mod tests {
             app_dir: None,
             entrypoint: None,
             startup_timeout_seconds: 30,
+            max_trajectory_length: 3,
         };
         let artifacts = std::env::temp_dir().join("test-artifacts");
         (config, artifacts)

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,10 @@ fn default_timeout() -> u64 {
     30
 }
 
+fn default_max_trajectory_length() -> usize {
+    crate::agent::context::DEFAULT_MAX_TRAJECTORY_LENGTH
+}
+
 fn default_provider() -> String {
     "anthropic".into()
 }
@@ -79,6 +83,10 @@ pub struct Config {
 
     #[serde(default = "default_timeout")]
     pub startup_timeout_seconds: u64,
+
+    /// Number of recent turns the agent keeps in its sliding context window (default: 3).
+    #[serde(default = "default_max_trajectory_length")]
+    pub max_trajectory_length: usize,
 }
 
 impl Config {
@@ -101,6 +109,7 @@ impl Config {
             app_dir: None,
             entrypoint: None,
             startup_timeout_seconds: default_timeout(),
+            max_trajectory_length: default_max_trajectory_length(),
         }
     }
 
@@ -268,6 +277,7 @@ mod tests {
         assert_eq!(config.vnc_bind_addr, "0.0.0.0");
         assert!(config.vnc_port.is_none());
         assert_eq!(config.startup_timeout_seconds, 30);
+        assert_eq!(config.max_trajectory_length, 3);
     }
 
     #[test]

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -673,6 +673,7 @@ mod tests {
             app_dir: None,
             entrypoint: None,
             startup_timeout_seconds: 30,
+            max_trajectory_length: 3,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,6 +741,7 @@ async fn run_agent_loop(
     let loop_config = agent::loop_v2::AgentLoopV2Config {
         debug,
         verbose,
+        max_trajectory_length: config.max_trajectory_length,
         ..Default::default()
     };
     let mut agent_loop = agent::loop_v2::AgentLoopV2::new(
@@ -1052,6 +1053,7 @@ async fn run_interactive_step_inner(
     let loop_config = agent::loop_v2::AgentLoopV2Config {
         debug,
         verbose,
+        max_trajectory_length: config.max_trajectory_length,
         ..Default::default()
     };
     let mut agent_loop = agent::loop_v2::AgentLoopV2::new(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -172,6 +172,7 @@ mod tests {
             app_dir: None,
             entrypoint: None,
             startup_timeout_seconds: 30,
+            max_trajectory_length: 3,
         };
         let session = DockerSession::create(&config, None).await.unwrap();
 
@@ -203,6 +204,7 @@ mod tests {
             app_dir: None,
             entrypoint: None,
             startup_timeout_seconds: 30,
+            max_trajectory_length: 3,
         };
         let session = DockerSession::create(&config, None).await.unwrap();
 
@@ -244,6 +246,7 @@ mod tests {
             app_dir: None,
             entrypoint: None,
             startup_timeout_seconds: 30,
+            max_trajectory_length: 3,
         };
         let session = DockerSession::create(&config, None).await.unwrap();
 
@@ -273,6 +276,7 @@ mod tests {
             app_dir: None,
             entrypoint: None,
             startup_timeout_seconds: 30,
+            max_trajectory_length: 3,
         };
         let session = DockerSession::create(&config, None).await.unwrap();
 
@@ -307,6 +311,7 @@ mod tests {
             app_dir: None,
             entrypoint: None,
             startup_timeout_seconds: 30,
+            max_trajectory_length: 3,
         };
         let session = DockerSession::create(&config, None).await.unwrap();
 


### PR DESCRIPTION
## Summary
- Adds `max_trajectory_length` field to `Config` (JSON config file), defaulting to 3
- Threads it through to `AgentLoopV2Config` so the agent's sliding context window size is tunable
- Useful for complex multi-step tasks that need more history, or token-constrained setups that need less

## Usage

In `config.json`:
```json
{
  "max_trajectory_length": 5
}
```

Omit the field to keep the default of 3 turns.

## Test plan
- [x] `cargo test` — 330 tests pass
- [x] Default value unchanged (3) — no behavior change without explicit config
- [x] All test Config struct literals updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)