### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "desktest"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktest"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [[bin]]


### PR DESCRIPTION
## Summary
- Patch version bump: `0.2.0` → `0.2.1`
- Updates `Cargo.toml` and `Cargo.lock`

## Post-merge
After merging, tag and push to trigger the release workflow:
```sh
git checkout master && git pull
git tag v0.2.1
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
