### PR TITLE
feat: add --replay flag to desktest attach

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,7 +178,8 @@ EXAMPLES:
 EXAMPLES:
   desktest attach task.json --container my-container
   desktest attach task.json --container abc123 --config config.json
-  desktest attach task.json --container my-container --resolution 1280x720")]
+  desktest attach task.json --container my-container --resolution 1280x720
+  desktest attach task.json --container my-container --replay")]
     Attach {
         /// Path to the task JSON file
         task: std::path::PathBuf,
@@ -186,6 +187,10 @@ EXAMPLES:
         /// Docker container ID or name to attach to (must be running)
         #[arg(long)]
         container: String,
+
+        /// Use the replay_script from the task JSON for deterministic execution (no LLM, no API costs)
+        #[arg(long, default_value_t = false)]
+        replay: bool,
     },
 
     /// Replay a codified Python script inside a container (deprecated: use `desktest run --replay` instead)

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,14 +152,21 @@ async fn main() {
                 }
             }
         }
-        Command::Attach { task, container } => {
-            let task_def = match task::TaskDefinition::load(task) {
+        Command::Attach { task, container, replay } => {
+            let mut task_def = match task::TaskDefinition::load(task) {
                 Ok(t) => t,
                 Err(e) => {
                     eprintln!("Task load error: {e}");
                     std::process::exit(e.exit_code());
                 }
             };
+
+            if *replay {
+                if let Err(e) = task_def.apply_replay_override() {
+                    eprintln!("Error: {e}");
+                    std::process::exit(e.exit_code());
+                }
+            }
 
             let run_config =
                 orchestration::load_config_or_defaults(&cli.config_flag, &cli.resolution);


### PR DESCRIPTION
## Summary
- Adds `--replay` flag to `desktest attach`, bringing parity with `desktest run --replay`
- Allows deterministic replay script execution against existing containers (no LLM, no API costs)
- Adds replay example to `attach` help text

## Test plan
- [ ] `cargo build` compiles cleanly
- [ ] `desktest attach --help` shows the new `--replay` flag
- [ ] `desktest attach task.json --container <id> --replay` runs the replay script from the task JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
