### PR TITLE
chore: bump to v0.10.0 with merge integration fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "desktest"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktest"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2024"
 
 [[bin]]

--- a/src/config.rs
+++ b/src/config.rs
@@ -417,7 +417,10 @@ mod tests {
             "vnc_bind_addr": "not-an-ip"
         }"#;
         let err = Config::parse_and_validate(json).unwrap_err();
-        assert!(err.to_string().contains("vnc_bind_addr is not a valid IP address"));
+        assert!(
+            err.to_string()
+                .contains("vnc_bind_addr is not a valid IP address")
+        );
     }
 
     #[test]
@@ -428,7 +431,10 @@ mod tests {
             "vnc_bind_addr": ""
         }"#;
         let err = Config::parse_and_validate(json).unwrap_err();
-        assert!(err.to_string().contains("vnc_bind_addr is not a valid IP address"));
+        assert!(
+            err.to_string()
+                .contains("vnc_bind_addr is not a valid IP address")
+        );
     }
 
     #[test]

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -61,7 +61,9 @@ impl DockerSession {
                 Err(bollard::errors::Error::DockerResponseServerError {
                     status_code: 404, ..
                 }) => {
-                    warn!("Custom image '{img}' not found locally — pulling from remote registry. Ensure you trust this image source.");
+                    warn!(
+                        "Custom image '{img}' not found locally — pulling from remote registry. Ensure you trust this image source."
+                    );
                     use bollard::image::CreateImageOptions;
                     let options = CreateImageOptions {
                         from_image: img,

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,11 @@ async fn main() {
                 }
             }
         }
-        Command::Attach { task, container, replay } => {
+        Command::Attach {
+            task,
+            container,
+            replay,
+        } => {
             let mut task_def = match task::TaskDefinition::load(task) {
                 Ok(t) => t,
                 Err(e) => {

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -485,7 +485,7 @@ async fn run_eval_loop(
 
             // Create trajectory logger so review HTML has something to display
             let mut trajectory_logger =
-                match crate::trajectory::TrajectoryLogger::new(artifacts_dir, verbose) {
+                match crate::trajectory::TrajectoryLogger::new(artifacts_dir, verbose, redactor.cloned()) {
                     Ok(tl) => Some(tl),
                     Err(e) => {
                         tracing::warn!("Failed to create trajectory logger, review HTML may be empty: {e}");


### PR DESCRIPTION
## Summary
- Bumps version to 0.10.0 for the task secrets feature release
- Passes redactor to the new programmatic-mode `TrajectoryLogger` call added in #43
- Minor linter formatting fixes

## Test plan
- [x] `cargo test` — all 405 tests pass
- [x] `cargo build` — clean compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
