### PR TITLE
feat: add two-tier opt-in telemetry system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,17 +114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,7 +427,6 @@ name = "desktest"
 version = "0.12.1"
 dependencies = [
  "assert_cmd",
- "atty",
  "axum",
  "base64",
  "bollard",
@@ -769,15 +757,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1278,7 +1257,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +438,7 @@ name = "desktest"
 version = "0.12.1"
 dependencies = [
  "assert_cmd",
+ "atty",
  "axum",
  "base64",
  "bollard",
@@ -451,6 +463,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "wiremock",
 ]
 
@@ -756,6 +769,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1190,6 +1212,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,7 +1278,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -1561,6 +1593,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1569,6 +1602,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -1580,12 +1614,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -2232,6 +2268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2320,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+dependencies = [
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -2412,6 +2465,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "multipart", "stream"] }
 bollard = "0.18"
 base64 = "0.22"
 tar = "0.4"
@@ -30,6 +30,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 dotenvy = "0.15.7"
 sha2 = "0.10.9"
+uuid = { version = "1", features = ["v4"] }
+atty = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 dotenvy = "0.15.7"
 sha2 = "0.10.9"
 uuid = { version = "1", features = ["v4"] }
-atty = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,18 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::results;
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum TelemetryAction {
+    /// Disable telemetry
+    Off,
+    /// Opt in to anonymous usage stats only
+    Anonymous,
+    /// Opt in to rich diagnostics (trajectories + screenshots)
+    Rich,
+    /// Show current telemetry settings
+    Status,
+}
 
 #[derive(Parser, Debug)]
 #[command(
@@ -293,8 +305,8 @@ EXAMPLES:
   desktest telemetry rich         # Opt in to rich diagnostics (trajectories + screenshots)
   desktest telemetry off          # Disable telemetry")]
     Telemetry {
-        /// Action: off, anonymous, rich, or status
-        action: String,
+        /// Action to perform
+        action: TelemetryAction,
     },
 
     /// Generate an interactive HTML trajectory viewer (best for human review in a browser)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -285,6 +285,18 @@ EXAMPLES:
         watch: std::path::PathBuf,
     },
 
+    /// Manage telemetry settings
+    #[command(after_help = "\
+EXAMPLES:
+  desktest telemetry status       # Show current telemetry settings
+  desktest telemetry anonymous    # Opt in to anonymous usage stats
+  desktest telemetry rich         # Opt in to rich diagnostics (trajectories + screenshots)
+  desktest telemetry off          # Disable telemetry")]
+    Telemetry {
+        /// Action: off, anonymous, rich, or status
+        action: String,
+    },
+
     /// Generate an interactive HTML trajectory viewer (best for human review in a browser)
     #[command(after_help = "\
 For a CLI/agent-friendly text view, use `desktest logs` instead.\n\n\

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,7 +349,12 @@ async fn main() {
             )
             .await;
 
-            record_run_event(&mut telemetry_client, &result, "interactive", cli.qa, false, bash_enabled, start_time);
+            // In interactive mode (no --step, no --validate-only), Ctrl+C is expected — not an error
+            let is_expected_interrupt = matches!(&result, Err(e) if !step && !validate_only && e.is_interrupt());
+
+            if !is_expected_interrupt {
+                record_run_event(&mut telemetry_client, &result, "interactive", cli.qa, false, bash_enabled, start_time);
+            }
 
             // Print result immediately so the user doesn't wait for telemetry flush
             let exit_code = match &result {
@@ -358,8 +363,7 @@ async fn main() {
                     if outcome.passed { 0 } else { 1 }
                 }
                 Err(e) => {
-                    // In interactive mode (no --step, no --validate-only), Ctrl+C is expected
-                    if !step && !validate_only && e.is_interrupt() {
+                    if is_expected_interrupt {
                         0
                     } else {
                         eprintln!("Error: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,10 +235,8 @@ async fn main() {
                 }
             };
 
-            // Suite manages its own per-test artifacts dirs, but set the output dir for suite-level upload
-            if let Some(ref dir) = cli.artifacts_dir {
-                telemetry_client.set_artifacts_dir(dir.clone());
-            }
+            // Suite manages its own per-test artifacts dirs; don't set telemetry artifacts_dir
+            // (--artifacts-dir is documented as ignored for suite runs)
             telemetry_client.flush().await;
 
             std::process::exit(exit_code);

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,6 +333,7 @@ async fn main() {
             }
 
             let bash_enabled = cli.with_bash || cli.qa;
+            let start_time = std::time::Instant::now();
             let result = interactive::run_interactive(
                 task_def,
                 run_config,
@@ -348,20 +349,32 @@ async fn main() {
             )
             .await;
 
-            match result {
+            record_run_event(&mut telemetry_client, &result, "interactive", cli.qa, false, bash_enabled, start_time);
+
+            // Print result immediately so the user doesn't wait for telemetry flush
+            let exit_code = match &result {
                 Ok(outcome) => {
                     println!("{outcome}");
-                    std::process::exit(if outcome.passed { 0 } else { 1 });
+                    if outcome.passed { 0 } else { 1 }
                 }
                 Err(e) => {
                     // In interactive mode (no --step, no --validate-only), Ctrl+C is expected
                     if !step && !validate_only && e.is_interrupt() {
-                        std::process::exit(0);
+                        0
+                    } else {
+                        eprintln!("Error: {e}");
+                        e.exit_code()
                     }
-                    eprintln!("Error: {e}");
-                    std::process::exit(e.exit_code());
                 }
-            }
+            };
+
+            let effective_artifacts_dir = cli.artifacts_dir.clone().unwrap_or_else(|| {
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")).join("desktest_artifacts")
+            });
+            telemetry_client.set_artifacts_dir(effective_artifacts_dir);
+            telemetry_client.flush().await;
+
+            std::process::exit(exit_code);
         }
         Command::Codify {
             trajectory,

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,8 @@ async fn main() {
 
             let run_config =
                 orchestration::load_config_or_defaults(&cli.config_flag, &cli.resolution);
+            let telem_provider = run_config.provider.clone();
+            let telem_model = run_config.model.clone();
 
             let needs_llm = !*replay && !task_def.is_programmatic_only();
             if let Err(e) = preflight::run_preflight(&run_config, needs_llm).await {
@@ -143,7 +145,7 @@ async fn main() {
             )
             .await;
 
-            record_run_event(&mut telemetry_client, &result, cmd_name, cli.qa, is_replay, bash_enabled, start_time);
+            record_run_event(&mut telemetry_client, &result, cmd_name, cli.qa, is_replay, bash_enabled, start_time, Some(&telem_provider), Some(&telem_model));
 
             // Print result immediately so the user doesn't wait for telemetry flush
             let exit_code = match &result {
@@ -208,6 +210,8 @@ async fn main() {
                     event.duration_ms = Some(suite_result.total_duration_ms);
                     event.used_qa_mode = cli.qa;
                     event.used_bash = bash_enabled;
+                    event.provider = Some(run_config.provider.clone());
+                    event.model = Some(run_config.model.clone());
                     telemetry_client.record_event(event);
                 }
                 Err(e) => {
@@ -217,6 +221,8 @@ async fn main() {
                     event.error_category = Some(format!("exit_{}", e.exit_code()));
                     event.used_qa_mode = cli.qa;
                     event.used_bash = bash_enabled;
+                    event.provider = Some(run_config.provider.clone());
+                    event.model = Some(run_config.model.clone());
                     telemetry_client.record_event(event);
                 }
             }
@@ -259,6 +265,8 @@ async fn main() {
 
             let run_config =
                 orchestration::load_config_or_defaults(&cli.config_flag, &cli.resolution);
+            let telem_provider = run_config.provider.clone();
+            let telem_model = run_config.model.clone();
 
             let needs_llm = !*replay && !task_def.is_programmatic_only();
             if let Err(e) = preflight::run_preflight(&run_config, needs_llm).await {
@@ -287,7 +295,7 @@ async fn main() {
             )
             .await;
 
-            record_run_event(&mut telemetry_client, &result, "attach", cli.qa, is_replay, bash_enabled, start_time);
+            record_run_event(&mut telemetry_client, &result, "attach", cli.qa, is_replay, bash_enabled, start_time, Some(&telem_provider), Some(&telem_model));
 
             // Print result immediately so the user doesn't wait for telemetry flush
             let exit_code = match &result {
@@ -324,6 +332,8 @@ async fn main() {
 
             let run_config =
                 orchestration::load_config_or_defaults(&cli.config_flag, &cli.resolution);
+            let telem_provider = run_config.provider.clone();
+            let telem_model = run_config.model.clone();
 
             // run_interactive_step unconditionally creates an LLM provider,
             // so any --step invocation needs an API key regardless of evaluator mode.
@@ -355,7 +365,7 @@ async fn main() {
             let is_expected_interrupt = matches!(&result, Err(e) if !step && !validate_only && e.is_interrupt());
 
             if !is_expected_interrupt {
-                record_run_event(&mut telemetry_client, &result, "interactive", cli.qa, false, bash_enabled, start_time);
+                record_run_event(&mut telemetry_client, &result, "interactive", cli.qa, false, bash_enabled, start_time, Some(&telem_provider), Some(&telem_model));
             }
 
             // Print result immediately so the user doesn't wait for telemetry flush
@@ -724,7 +734,7 @@ async fn main() {
     }
 }
 
-/// Record a telemetry event for a single test run (used by Run and Attach commands).
+/// Record a telemetry event for a single test run (used by Run, Attach, and Interactive commands).
 fn record_run_event(
     client: &mut telemetry::TelemetryClient,
     result: &Result<crate::error::AgentOutcome, crate::error::AppError>,
@@ -733,6 +743,8 @@ fn record_run_event(
     replay: bool,
     bash_enabled: bool,
     start_time: std::time::Instant,
+    provider: Option<&str>,
+    model: Option<&str>,
 ) {
     let duration_ms = start_time.elapsed().as_millis() as u64;
     let mut event = telemetry::build_event(client, "test_completed", command);
@@ -740,6 +752,8 @@ fn record_run_event(
     event.used_qa_mode = qa;
     event.used_replay = replay;
     event.used_bash = bash_enabled;
+    event.provider = provider.map(|s| s.to_string());
+    event.model = model.map(|s| s.to_string());
 
     match result {
         Ok(outcome) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod review;
 mod setup;
 mod suite;
 mod task;
+mod telemetry;
 mod trajectory;
 mod update;
 
@@ -69,6 +70,19 @@ async fn main() {
     let cli = Cli::parse();
     setup_logging(cli.debug);
 
+    let mut telemetry_client = telemetry::TelemetryClient::load_or_init();
+
+    // Handle `desktest telemetry <action>` subcommand early
+    if let Command::Telemetry { action } = &cli.command {
+        telemetry_client.handle_command(action);
+        std::process::exit(0);
+    }
+
+    // Check consent / show prompt / nudge (only for test commands)
+    if telemetry::is_test_command(&cli.command) {
+        telemetry_client.check_consent();
+    }
+
     match &cli.command {
         Command::Validate { task } => match task::TaskDefinition::load(task) {
             Ok(task_def) => {
@@ -111,7 +125,10 @@ async fn main() {
 
             let monitor_handle = maybe_start_monitor(cli.monitor, cli.monitor_port).await;
             let bash_enabled = cli.with_bash || cli.qa;
+            let start_time = std::time::Instant::now();
 
+            let cmd_name = telemetry::command_name(&cli.command);
+            let is_replay = *replay;
             let result = orchestration::run_task(
                 task_def,
                 run_config,
@@ -125,6 +142,14 @@ async fn main() {
                 cli.artifacts_dir.clone(),
             )
             .await;
+
+            record_run_event(&mut telemetry_client, &result, cmd_name, cli.qa, is_replay, bash_enabled, start_time);
+
+            if let Some(ref dir) = cli.artifacts_dir {
+                telemetry_client.set_artifacts_dir(dir.clone());
+            }
+            telemetry_client.flush().await;
+
             match result {
                 Ok(outcome) => {
                     println!("{outcome}");
@@ -155,6 +180,7 @@ async fn main() {
             let monitor_handle = maybe_start_monitor(cli.monitor, cli.monitor_port).await;
             let bash_enabled = cli.with_bash || cli.qa;
 
+            let start_time = std::time::Instant::now();
             let result = suite::run_suite(
                 dir,
                 cli.config_flag.as_deref(),
@@ -169,6 +195,26 @@ async fn main() {
                 cli.qa,
             )
             .await;
+
+            // Record suite telemetry event
+            match &result {
+                Ok(suite_result) => {
+                    let mut event = telemetry::build_event(&telemetry_client, "suite_completed", "suite");
+                    event.status = Some(if suite_result.summary.failed == 0 && suite_result.summary.errors == 0 { "pass" } else { "fail" }.to_string());
+                    event.duration_ms = Some(suite_result.total_duration_ms);
+                    event.used_qa_mode = cli.qa;
+                    event.used_bash = bash_enabled;
+                    telemetry_client.record_event(event);
+                }
+                Err(e) => {
+                    let mut event = telemetry::build_event(&telemetry_client, "error", "suite");
+                    event.status = Some("error".to_string());
+                    event.duration_ms = Some(start_time.elapsed().as_millis() as u64);
+                    event.error_category = Some(format!("exit_{}", e.exit_code()));
+                    telemetry_client.record_event(event);
+                }
+            }
+            telemetry_client.flush().await;
 
             match result {
                 Ok(suite_result) => {
@@ -212,6 +258,8 @@ async fn main() {
 
             let monitor_handle = maybe_start_monitor(cli.monitor, cli.monitor_port).await;
             let bash_enabled = cli.with_bash || cli.qa;
+            let start_time = std::time::Instant::now();
+            let is_replay = *replay;
 
             let result = orchestration::run_attach(
                 task_def,
@@ -227,6 +275,14 @@ async fn main() {
                 cli.artifacts_dir.clone(),
             )
             .await;
+
+            record_run_event(&mut telemetry_client, &result, "attach", cli.qa, is_replay, bash_enabled, start_time);
+
+            if let Some(ref dir) = cli.artifacts_dir {
+                telemetry_client.set_artifacts_dir(dir.clone());
+            }
+            telemetry_client.flush().await;
+
             match result {
                 Ok(outcome) => {
                     println!("{outcome}");
@@ -629,5 +685,40 @@ async fn main() {
                 std::process::exit(e.exit_code());
             }
         },
+        Command::Telemetry { .. } => {
+            // Handled above before the match; this arm is unreachable
+            unreachable!()
+        }
     }
+}
+
+/// Record a telemetry event for a single test run (used by Run and Attach commands).
+fn record_run_event(
+    client: &mut telemetry::TelemetryClient,
+    result: &Result<crate::error::AgentOutcome, crate::error::AppError>,
+    command: &str,
+    qa: bool,
+    replay: bool,
+    bash_enabled: bool,
+    start_time: std::time::Instant,
+) {
+    let duration_ms = start_time.elapsed().as_millis() as u64;
+    let mut event = telemetry::build_event(client, "test_completed", command);
+    event.duration_ms = Some(duration_ms);
+    event.used_qa_mode = qa;
+    event.used_replay = replay;
+    event.used_bash = bash_enabled;
+
+    match result {
+        Ok(outcome) => {
+            event.status = Some(if outcome.passed { "pass" } else { "fail" }.to_string());
+        }
+        Err(e) => {
+            event.event_type = "error".to_string();
+            event.status = Some("error".to_string());
+            event.error_category = Some(format!("exit_{}", e.exit_code()));
+        }
+    }
+
+    client.record_event(event);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,9 +145,10 @@ async fn main() {
 
             record_run_event(&mut telemetry_client, &result, cmd_name, cli.qa, is_replay, bash_enabled, start_time);
 
-            if let Some(ref dir) = cli.artifacts_dir {
-                telemetry_client.set_artifacts_dir(dir.clone());
-            }
+            let effective_artifacts_dir = cli.artifacts_dir.clone().unwrap_or_else(|| {
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")).join("desktest_artifacts")
+            });
+            telemetry_client.set_artifacts_dir(effective_artifacts_dir);
             telemetry_client.flush().await;
 
             match result {
@@ -214,6 +215,10 @@ async fn main() {
                     telemetry_client.record_event(event);
                 }
             }
+            // Suite manages its own per-test artifacts dirs, but set the output dir for suite-level upload
+            if let Some(ref dir) = cli.artifacts_dir {
+                telemetry_client.set_artifacts_dir(dir.clone());
+            }
             telemetry_client.flush().await;
 
             match result {
@@ -278,9 +283,10 @@ async fn main() {
 
             record_run_event(&mut telemetry_client, &result, "attach", cli.qa, is_replay, bash_enabled, start_time);
 
-            if let Some(ref dir) = cli.artifacts_dir {
-                telemetry_client.set_artifacts_dir(dir.clone());
-            }
+            let effective_artifacts_dir = cli.artifacts_dir.clone().unwrap_or_else(|| {
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")).join("desktest_artifacts")
+            });
+            telemetry_client.set_artifacts_dir(effective_artifacts_dir);
             telemetry_client.flush().await;
 
             match result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,22 +145,25 @@ async fn main() {
 
             record_run_event(&mut telemetry_client, &result, cmd_name, cli.qa, is_replay, bash_enabled, start_time);
 
+            // Print result immediately so the user doesn't wait for telemetry flush
+            let exit_code = match &result {
+                Ok(outcome) => {
+                    println!("{outcome}");
+                    if outcome.passed { 0 } else { 1 }
+                }
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    e.exit_code()
+                }
+            };
+
             let effective_artifacts_dir = cli.artifacts_dir.clone().unwrap_or_else(|| {
                 std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")).join("desktest_artifacts")
             });
             telemetry_client.set_artifacts_dir(effective_artifacts_dir);
             telemetry_client.flush().await;
 
-            match result {
-                Ok(outcome) => {
-                    println!("{outcome}");
-                    std::process::exit(if outcome.passed { 0 } else { 1 });
-                }
-                Err(e) => {
-                    eprintln!("Error: {e}");
-                    std::process::exit(e.exit_code());
-                }
-            }
+            std::process::exit(exit_code);
         }
         Command::Suite { dir, filter } => {
             if cli.artifacts_dir.is_some() {
@@ -215,21 +218,22 @@ async fn main() {
                     telemetry_client.record_event(event);
                 }
             }
+            // Print result immediately so the user doesn't wait for telemetry flush
+            let exit_code = match &result {
+                Ok(suite_result) => suite::suite_exit_code(suite_result),
+                Err(e) => {
+                    eprintln!("Suite error: {e}");
+                    e.exit_code()
+                }
+            };
+
             // Suite manages its own per-test artifacts dirs, but set the output dir for suite-level upload
             if let Some(ref dir) = cli.artifacts_dir {
                 telemetry_client.set_artifacts_dir(dir.clone());
             }
             telemetry_client.flush().await;
 
-            match result {
-                Ok(suite_result) => {
-                    std::process::exit(suite::suite_exit_code(&suite_result));
-                }
-                Err(e) => {
-                    eprintln!("Suite error: {e}");
-                    std::process::exit(e.exit_code());
-                }
-            }
+            std::process::exit(exit_code);
         }
         Command::Attach {
             task,
@@ -283,22 +287,25 @@ async fn main() {
 
             record_run_event(&mut telemetry_client, &result, "attach", cli.qa, is_replay, bash_enabled, start_time);
 
+            // Print result immediately so the user doesn't wait for telemetry flush
+            let exit_code = match &result {
+                Ok(outcome) => {
+                    println!("{outcome}");
+                    if outcome.passed { 0 } else { 1 }
+                }
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    e.exit_code()
+                }
+            };
+
             let effective_artifacts_dir = cli.artifacts_dir.clone().unwrap_or_else(|| {
                 std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")).join("desktest_artifacts")
             });
             telemetry_client.set_artifacts_dir(effective_artifacts_dir);
             telemetry_client.flush().await;
 
-            match result {
-                Ok(outcome) => {
-                    println!("{outcome}");
-                    std::process::exit(if outcome.passed { 0 } else { 1 });
-                }
-                Err(e) => {
-                    eprintln!("Error: {e}");
-                    std::process::exit(e.exit_code());
-                }
-            }
+            std::process::exit(exit_code);
         }
         Command::Interactive {
             task,

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,7 @@ async fn main() {
                     let mut event = telemetry::build_event(&telemetry_client, "suite_completed", "suite");
                     event.status = Some(if suite_result.summary.failed == 0 && suite_result.summary.errors == 0 { "pass" } else { "fail" }.to_string());
                     event.duration_ms = Some(suite_result.total_duration_ms);
-                    event.used_qa_mode = cli.qa;
+                    event.used_qa = cli.qa;
                     event.used_bash = bash_enabled;
                     event.provider = Some(run_config.provider.clone());
                     event.model = Some(run_config.model.clone());
@@ -219,7 +219,7 @@ async fn main() {
                     event.status = Some("error".to_string());
                     event.duration_ms = Some(start_time.elapsed().as_millis() as u64);
                     event.error_category = Some(format!("exit_{}", e.exit_code()));
-                    event.used_qa_mode = cli.qa;
+                    event.used_qa = cli.qa;
                     event.used_bash = bash_enabled;
                     event.provider = Some(run_config.provider.clone());
                     event.model = Some(run_config.model.clone());
@@ -750,7 +750,7 @@ fn record_run_event(
     let duration_ms = start_time.elapsed().as_millis() as u64;
     let mut event = telemetry::build_event(client, "test_completed", command);
     event.duration_ms = Some(duration_ms);
-    event.used_qa_mode = qa;
+    event.used_qa = qa;
     event.used_replay = replay;
     event.used_bash = bash_enabled;
     event.provider = provider.map(|s| s.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,8 @@ async fn main() {
                     event.status = Some("error".to_string());
                     event.duration_ms = Some(start_time.elapsed().as_millis() as u64);
                     event.error_category = Some(format!("exit_{}", e.exit_code()));
+                    event.used_qa_mode = cli.qa;
+                    event.used_bash = bash_enabled;
                     telemetry_client.record_event(event);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -384,11 +384,14 @@ async fn main() {
                 }
             };
 
-            let effective_artifacts_dir = cli.artifacts_dir.clone().unwrap_or_else(|| {
-                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")).join("desktest_artifacts")
-            });
-            telemetry_client.set_artifacts_dir(effective_artifacts_dir);
-            telemetry_client.flush().await;
+            // Skip telemetry flush on expected Ctrl+C to avoid orphaned artifact uploads
+            if !is_expected_interrupt {
+                let effective_artifacts_dir = cli.artifacts_dir.clone().unwrap_or_else(|| {
+                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")).join("desktest_artifacts")
+                });
+                telemetry_client.set_artifacts_dir(effective_artifacts_dir);
+                telemetry_client.flush().await;
+            }
 
             std::process::exit(exit_code);
         }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -99,7 +99,10 @@ impl TelemetryClient {
                 "0" => ConsentLevel::None,
                 "1" => ConsentLevel::Anonymous,
                 "2" => ConsentLevel::Rich,
-                _ => ConsentLevel::None,
+                other => {
+                    eprintln!("Warning: unrecognized DESKTEST_TELEMETRY value '{other}'. Expected 0, 1, or 2. Defaulting to off.");
+                    ConsentLevel::None
+                }
             };
         }
 
@@ -205,34 +208,36 @@ impl TelemetryClient {
 
     /// Flush all queued events to the backend. Fire-and-forget with timeout.
     pub async fn flush(&mut self) {
-        if self.config.consent_level == ConsentLevel::None || self.events.is_empty() {
+        if self.config.consent_level == ConsentLevel::None {
             return;
         }
 
         let client = reqwest::Client::new();
-        let url = format!("{}/api/events", self.base_url);
 
-        // Send anonymous events
-        let events = std::mem::take(&mut self.events);
-        let send_result = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            client.post(&url).json(&events).send(),
-        )
-        .await;
+        // Send anonymous events (if any were queued)
+        if !self.events.is_empty() {
+            let url = format!("{}/api/events", self.base_url);
+            let events = std::mem::take(&mut self.events);
+            let send_result = tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                client.post(&url).json(&events).send(),
+            )
+            .await;
 
-        match send_result {
-            Ok(Ok(resp)) => {
-                debug!("Telemetry events sent: status {}", resp.status());
-            }
-            Ok(Err(e)) => {
-                debug!("Telemetry send failed (ignored): {e}");
-            }
-            Err(_) => {
-                debug!("Telemetry send timed out (ignored)");
+            match send_result {
+                Ok(Ok(resp)) => {
+                    debug!("Telemetry events sent: status {}", resp.status());
+                }
+                Ok(Err(e)) => {
+                    debug!("Telemetry send failed (ignored): {e}");
+                }
+                Err(_) => {
+                    debug!("Telemetry send timed out (ignored)");
+                }
             }
         }
 
-        // Rich tier: upload artifacts tarball
+        // Rich tier: upload artifacts tarball (independent of events)
         if self.config.consent_level == ConsentLevel::Rich {
             if let Some(ref artifacts_dir) = self.artifacts_dir {
                 if artifacts_dir.exists() {
@@ -448,6 +453,11 @@ fn epoch_days_to_ymd(days: u64) -> (u64, u64, u64) {
 
 /// Create a gzipped tarball of the artifacts directory.
 /// Excludes potentially sensitive files (home directory contents, logs).
+///
+/// Note: Only includes files in the top-level directory (non-recursive).
+/// The desktest artifacts directory is flat by design — trajectory.jsonl,
+/// screenshots, task.json, and a11y trees are all written directly into it.
+/// Suite runs use separate per-test artifact directories.
 fn create_artifacts_tarball(artifacts_dir: &std::path::Path) -> Result<Vec<u8>, std::io::Error> {
     use flate2::write::GzEncoder;
     use flate2::Compression;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -91,16 +91,18 @@ impl TelemetryClient {
         let base_url = std::env::var("DESKTEST_TELEMETRY_URL")
             .unwrap_or_else(|_| DEFAULT_TELEMETRY_URL.to_string());
 
-        let existing = load_config();
+        let (existing, was_corrupt) = load_config();
         let was_fresh = existing.is_none();
         let mut config = existing.unwrap_or_default();
         let mut is_env_override = false;
 
-        // Persist the config if freshly generated, so install_id is stable across runs.
+        // Persist the config if freshly generated (or reset after corruption),
+        // so install_id is stable across runs.
         // Done before env override to avoid leaking an env-overridden consent level to disk.
         if was_fresh {
             let _ = save_config(&config);
         }
+        let _ = was_corrupt; // consumed by the warning in load_config
 
         if let Some(val) = env_override {
             is_env_override = true;
@@ -143,8 +145,11 @@ impl TelemetryClient {
             self.show_nudge();
         }
 
-        self.config.run_count_since_prompt += 1;
-        let _ = save_config(&self.config);
+        // Only increment and persist for users who can be nudged (not Rich)
+        if self.config.consent_level != ConsentLevel::Rich {
+            self.config.run_count_since_prompt += 1;
+            let _ = save_config(&self.config);
+        }
     }
 
     /// Handle the `desktest telemetry <action>` subcommand.
@@ -409,10 +414,29 @@ fn state_file_path() -> Option<PathBuf> {
     config_dir().map(|d| d.join(STATE_FILE_NAME))
 }
 
-fn load_config() -> Option<TelemetryConfig> {
-    let path = state_file_path()?;
-    let data = std::fs::read_to_string(&path).ok()?;
-    serde_json::from_str(&data).ok()
+/// Load telemetry config from disk.
+/// Returns (Some(config), false) on success, (None, false) if file doesn't exist,
+/// or (None, true) if the file exists but is corrupt.
+fn load_config() -> (Option<TelemetryConfig>, bool) {
+    let path = match state_file_path() {
+        Some(p) => p,
+        None => return (None, false),
+    };
+    let data = match std::fs::read_to_string(&path) {
+        Ok(d) => d,
+        Err(_) => return (None, false), // file doesn't exist
+    };
+    match serde_json::from_str(&data) {
+        Ok(config) => (Some(config), false),
+        Err(e) => {
+            eprintln!(
+                "Warning: telemetry config at '{}' is corrupt ({}), resetting. Your install_id will change.",
+                path.display(),
+                e
+            );
+            (None, true)
+        }
+    }
 }
 
 fn save_config(config: &TelemetryConfig) -> Result<(), std::io::Error> {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -91,7 +91,9 @@ impl TelemetryClient {
         let base_url = std::env::var("DESKTEST_TELEMETRY_URL")
             .unwrap_or_else(|_| DEFAULT_TELEMETRY_URL.to_string());
 
-        let mut config = load_config().unwrap_or_default();
+        let existing = load_config();
+        let was_fresh = existing.is_none();
+        let mut config = existing.unwrap_or_default();
         let mut is_env_override = false;
 
         if let Some(val) = env_override {
@@ -105,6 +107,11 @@ impl TelemetryClient {
                     ConsentLevel::None
                 }
             };
+        }
+
+        // Persist the config if it was freshly generated, so install_id is stable across runs
+        if was_fresh {
+            let _ = save_config(&config);
         }
 
         Self {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -274,7 +274,7 @@ impl TelemetryClient {
         }
         // +1 accounts for the increment that happens after this check in check_consent()
         let next_count = self.config.run_count_since_prompt + 1;
-        next_count > 0 && next_count % NUDGE_INTERVAL == 0
+        next_count % NUDGE_INTERVAL == 0
     }
 
     fn show_first_run_prompt(&mut self) {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -424,7 +424,15 @@ fn load_config() -> (Option<TelemetryConfig>, bool) {
     };
     let data = match std::fs::read_to_string(&path) {
         Ok(d) => d,
-        Err(_) => return (None, false), // file doesn't exist
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return (None, false),
+        Err(e) => {
+            eprintln!(
+                "Warning: cannot read telemetry config at '{}' ({}), resetting. Your install_id will change.",
+                path.display(),
+                e
+            );
+            return (None, true);
+        }
     };
     match serde_json::from_str(&data) {
         Ok(config) => (Some(config), false),

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -96,6 +96,12 @@ impl TelemetryClient {
         let mut config = existing.unwrap_or_default();
         let mut is_env_override = false;
 
+        // Persist the config if freshly generated, so install_id is stable across runs.
+        // Done before env override to avoid leaking an env-overridden consent level to disk.
+        if was_fresh {
+            let _ = save_config(&config);
+        }
+
         if let Some(val) = env_override {
             is_env_override = true;
             config.consent_level = match val.as_str() {
@@ -107,11 +113,6 @@ impl TelemetryClient {
                     ConsentLevel::None
                 }
             };
-        }
-
-        // Persist the config if it was freshly generated, so install_id is stable across runs
-        if was_fresh {
-            let _ = save_config(&config);
         }
 
         Self {
@@ -307,18 +308,12 @@ impl TelemetryClient {
     }
 
     fn show_nudge(&self) {
-        match self.config.consent_level {
-            ConsentLevel::None => {
-                eprintln!(
-                    "Tip: Help improve desktest \u{2014} run `desktest telemetry anonymous` to opt in"
-                );
-            }
-            ConsentLevel::Anonymous => {
-                eprintln!(
-                    "Tip: Share richer diagnostics with `desktest telemetry rich`"
-                );
-            }
-            ConsentLevel::Rich => {} // no nudge
+        // Only Anonymous users reach here (Rich is excluded by should_nudge,
+        // None+prompted is excluded, None+unprompted goes to first-run prompt)
+        if self.config.consent_level == ConsentLevel::Anonymous {
+            eprintln!(
+                "Tip: Share richer diagnostics with `desktest telemetry rich`"
+            );
         }
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -26,6 +26,7 @@ impl std::fmt::Display for ConsentLevel {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TelemetryConfig {
     pub consent_level: ConsentLevel,
     pub install_id: String,
@@ -493,17 +494,7 @@ fn create_artifacts_tarball(artifacts_dir: &std::path::Path) -> Result<Vec<u8>, 
                 None => continue,
             };
 
-            // Redact home directory paths in file names (shouldn't happen, but safety)
-            let home_str = dirs_home()
-                .map(|h| h.to_string_lossy().to_string())
-                .unwrap_or_default();
-            let archive_name = if home_str.is_empty() {
-                file_name.clone()
-            } else {
-                file_name.replace(&home_str, "~")
-            };
-
-            archive.append_path_with_name(&path, &archive_name)?;
+            archive.append_path_with_name(&path, &file_name)?;
         }
     }
 
@@ -665,7 +656,7 @@ mod tests {
     #[test]
     fn test_event_serialization() {
         let event = TelemetryEvent {
-            timestamp: "12345Z".to_string(),
+            timestamp: "2025-03-25T10:13:20Z".to_string(),
             desktest_version: "0.12.0".to_string(),
             install_id: "test-id".to_string(),
             event_type: "test_completed".to_string(),

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -156,30 +156,31 @@ impl TelemetryClient {
     }
 
     /// Handle the `desktest telemetry <action>` subcommand.
-    pub fn handle_command(&mut self, action: &str) {
+    pub fn handle_command(&mut self, action: &crate::cli::TelemetryAction) {
+        use crate::cli::TelemetryAction;
         match action {
-            "off" => {
+            TelemetryAction::Off => {
                 self.config.consent_level = ConsentLevel::None;
                 self.config.prompted_at = Some(now_iso8601());
                 self.config.run_count_since_prompt = 0;
                 let _ = save_config(&self.config);
                 eprintln!("Telemetry disabled.");
             }
-            "anonymous" => {
+            TelemetryAction::Anonymous => {
                 self.config.consent_level = ConsentLevel::Anonymous;
                 self.config.prompted_at = Some(now_iso8601());
                 self.config.run_count_since_prompt = 0;
                 let _ = save_config(&self.config);
                 eprintln!("Telemetry set to anonymous (usage stats only).");
             }
-            "rich" => {
+            TelemetryAction::Rich => {
                 self.config.consent_level = ConsentLevel::Rich;
                 self.config.prompted_at = Some(now_iso8601());
                 self.config.run_count_since_prompt = 0;
                 let _ = save_config(&self.config);
                 eprintln!("Telemetry set to rich (usage stats + trajectories & screenshots).");
             }
-            "status" => {
+            TelemetryAction::Status => {
                 println!("Telemetry status:");
                 println!("  Consent level:    {}", self.config.consent_level);
                 println!("  Install ID:       {}", self.config.install_id);
@@ -190,12 +191,6 @@ impl TelemetryClient {
                 if let Some(ref ts) = self.config.prompted_at {
                     println!("  Last prompted:    {ts}");
                 }
-            }
-            other => {
-                eprintln!(
-                    "Unknown telemetry action: '{other}'. Use: off, anonymous, rich, or status"
-                );
-                std::process::exit(2);
             }
         }
     }
@@ -473,7 +468,9 @@ fn save_config(config: &TelemetryConfig) -> Result<(), std::io::Error> {
     // Atomic write: write to temp file then rename to avoid corruption on mid-write crash
     let tmp_path = path.with_extension("json.tmp");
     std::fs::write(&tmp_path, &json)?;
-    std::fs::rename(&tmp_path, &path)
+    std::fs::rename(&tmp_path, &path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp_path);
+    })
 }
 
 fn now_iso8601() -> String {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -229,10 +229,18 @@ impl TelemetryClient {
             return;
         }
 
+        let has_events = !self.events.is_empty();
+        let has_artifacts = self.config.consent_level == ConsentLevel::Rich
+            && self.artifacts_dir.as_ref().is_some_and(|d| d.exists());
+
+        if !has_events && !has_artifacts {
+            return;
+        }
+
         let client = reqwest::Client::new();
 
         // Send anonymous events (if any were queued)
-        if !self.events.is_empty() {
+        if has_events {
             let url = format!("{}/api/events", self.base_url);
             let events = std::mem::take(&mut self.events);
             let send_result = tokio::time::timeout(
@@ -531,8 +539,9 @@ fn create_artifacts_tarball(artifacts_dir: &std::path::Path) -> Result<Vec<u8>, 
             let ext = path
                 .extension()
                 .and_then(|e| e.to_str())
-                .unwrap_or("");
-            if !allowed_extensions.contains(&ext) {
+                .unwrap_or("")
+                .to_lowercase();
+            if !allowed_extensions.contains(&ext.as_str()) {
                 continue;
             }
             let file_name = match path.file_name() {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -145,8 +145,11 @@ impl TelemetryClient {
             self.show_nudge();
         }
 
-        // Only increment and persist for users who can be nudged (not Rich)
-        if self.config.consent_level != ConsentLevel::Rich {
+        // Only increment and persist for users who can be nudged
+        // (not Rich, and not explicitly opted out via `desktest telemetry off`)
+        let can_be_nudged = self.config.consent_level != ConsentLevel::Rich
+            && !(self.config.consent_level == ConsentLevel::None && self.config.prompted_at.is_some());
+        if can_be_nudged {
             self.config.run_count_since_prompt += 1;
             let _ = save_config(&self.config);
         }
@@ -459,7 +462,10 @@ fn save_config(config: &TelemetryConfig) -> Result<(), std::io::Error> {
     };
     let json = serde_json::to_string_pretty(config)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-    std::fs::write(&path, json)
+    // Atomic write: write to temp file then rename to avoid corruption on mid-write crash
+    let tmp_path = path.with_extension("json.tmp");
+    std::fs::write(&tmp_path, &json)?;
+    std::fs::rename(&tmp_path, &path)
 }
 
 fn now_iso8601() -> String {
@@ -510,7 +516,13 @@ fn create_artifacts_tarball(artifacts_dir: &std::path::Path) -> Result<Vec<u8>, 
     // Only include known safe file types
     let allowed_extensions = ["jsonl", "json", "png", "jpg", "txt"];
 
-    if let Ok(entries) = fs::read_dir(artifacts_dir) {
+    match fs::read_dir(artifacts_dir) {
+        Err(e) => {
+            debug!("Cannot read artifacts directory '{}': {e}", artifacts_dir.display());
+            let encoder = archive.into_inner()?;
+            return encoder.finish();
+        }
+        Ok(entries) => {
         for entry in entries.flatten() {
             let path = entry.path();
             if !path.is_file() {
@@ -529,6 +541,7 @@ fn create_artifacts_tarball(artifacts_dir: &std::path::Path) -> Result<Vec<u8>, 
             };
 
             archive.append_path_with_name(&path, &file_name)?;
+        }
         }
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -67,7 +67,7 @@ pub struct TelemetryEvent {
     pub agent_steps: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_category: Option<String>,
-    pub used_qa_mode: bool,
+    pub used_qa: bool,
     pub used_replay: bool,
     pub used_bash: bool,
     pub platform: String,
@@ -237,9 +237,10 @@ impl TelemetryClient {
         if has_events {
             let url = format!("{}/api/events", self.base_url);
             let events = std::mem::take(&mut self.events);
+            let payload = serde_json::json!({ "events": events });
             let send_result = tokio::time::timeout(
                 std::time::Duration::from_secs(5),
-                client.post(&url).json(&events).send(),
+                client.post(&url).json(&payload).send(),
             )
             .await;
 
@@ -335,18 +336,23 @@ impl TelemetryClient {
         };
 
         let url = format!("{}/api/upload", self.base_url);
+        let run_id = uuid::Uuid::new_v4().to_string();
         let part = reqwest::multipart::Part::bytes(tarball)
             .file_name("artifacts.tar.gz")
             .mime_str("application/gzip")
             .expect("hardcoded MIME type is always valid");
 
         let form = reqwest::multipart::Form::new()
-            .text("install_id", self.config.install_id.clone())
-            .part("artifacts", part);
+            .part("archive", part);
 
         let send_result = tokio::time::timeout(
             std::time::Duration::from_secs(30),
-            client.post(&url).multipart(form).send(),
+            client
+                .post(&url)
+                .header("X-Install-Id", &self.config.install_id)
+                .header("X-Run-Id", &run_id)
+                .multipart(form)
+                .send(),
         )
         .await;
 
@@ -379,7 +385,7 @@ pub fn build_event(client: &TelemetryClient, event_type: &str, command: &str) ->
         duration_ms: None,
         agent_steps: None,
         error_category: None,
-        used_qa_mode: false,
+        used_qa: false,
         used_replay: false,
         used_bash: false,
         platform: std::env::consts::OS.to_string(),
@@ -715,7 +721,7 @@ mod tests {
             duration_ms: Some(5000),
             agent_steps: Some(10),
             error_category: None,
-            used_qa_mode: false,
+            used_qa: false,
             used_replay: false,
             used_bash: true,
             platform: "linux".to_string(),

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -91,7 +91,7 @@ impl TelemetryClient {
         let base_url = std::env::var("DESKTEST_TELEMETRY_URL")
             .unwrap_or_else(|_| DEFAULT_TELEMETRY_URL.to_string());
 
-        let (existing, was_corrupt) = load_config();
+        let existing = load_config();
         let was_fresh = existing.is_none();
         let mut config = existing.unwrap_or_default();
         let mut is_env_override = false;
@@ -102,7 +102,6 @@ impl TelemetryClient {
         if was_fresh {
             let _ = save_config(&config);
         }
-        let _ = was_corrupt; // consumed by the warning in load_config
 
         if let Some(val) = env_override {
             is_env_override = true;
@@ -319,13 +318,11 @@ impl TelemetryClient {
     }
 
     fn show_nudge(&self) {
-        // Only Anonymous users reach here (Rich is excluded by should_nudge,
-        // None+prompted is excluded, None+unprompted goes to first-run prompt)
-        if self.config.consent_level == ConsentLevel::Anonymous {
-            eprintln!(
-                "Tip: Share richer diagnostics with `desktest telemetry rich`"
-            );
-        }
+        // Only Anonymous users reach here — Rich and None+prompted are
+        // excluded by should_nudge(), None+unprompted goes to first-run prompt
+        eprintln!(
+            "Tip: Share richer diagnostics with `desktest telemetry rich`"
+        );
     }
 
     async fn upload_artifacts(&self, client: &reqwest::Client, artifacts_dir: &std::path::Path) {
@@ -421,34 +418,31 @@ fn state_file_path() -> Option<PathBuf> {
 }
 
 /// Load telemetry config from disk.
-/// Returns (Some(config), false) on success, (None, false) if file doesn't exist,
-/// or (None, true) if the file exists but is corrupt.
-fn load_config() -> (Option<TelemetryConfig>, bool) {
-    let path = match state_file_path() {
-        Some(p) => p,
-        None => return (None, false),
-    };
+/// Returns Some(config) on success, None if missing or corrupt.
+/// Warnings are printed to stderr for I/O errors and corrupt files.
+fn load_config() -> Option<TelemetryConfig> {
+    let path = state_file_path()?;
     let data = match std::fs::read_to_string(&path) {
         Ok(d) => d,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return (None, false),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
         Err(e) => {
             eprintln!(
                 "Warning: cannot read telemetry config at '{}' ({}), resetting. Your install_id will change.",
                 path.display(),
                 e
             );
-            return (None, true);
+            return None;
         }
     };
     match serde_json::from_str(&data) {
-        Ok(config) => (Some(config), false),
+        Ok(config) => Some(config),
         Err(e) => {
             eprintln!(
                 "Warning: telemetry config at '{}' is corrupt ({}), resetting. Your install_id will change.",
                 path.display(),
                 e
             );
-            (None, true)
+            None
         }
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,668 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+const DEFAULT_TELEMETRY_URL: &str = "https://telemetry.desktest.dev";
+const STATE_FILE_NAME: &str = "telemetry.json";
+const NUDGE_INTERVAL: u32 = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsentLevel {
+    None,
+    Anonymous,
+    Rich,
+}
+
+impl std::fmt::Display for ConsentLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConsentLevel::None => write!(f, "none"),
+            ConsentLevel::Anonymous => write!(f, "anonymous"),
+            ConsentLevel::Rich => write!(f, "rich"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryConfig {
+    pub consent_level: ConsentLevel,
+    pub install_id: String,
+    pub prompted_at: Option<String>,
+    pub run_count_since_prompt: u32,
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            consent_level: ConsentLevel::None,
+            install_id: uuid::Uuid::new_v4().to_string(),
+            prompted_at: None,
+            run_count_since_prompt: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TelemetryEvent {
+    pub timestamp: String,
+    pub desktest_version: String,
+    pub install_id: String,
+    pub event_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evaluator_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_steps: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_category: Option<String>,
+    pub used_qa_mode: bool,
+    pub used_replay: bool,
+    pub used_bash: bool,
+    pub platform: String,
+    pub command: String,
+}
+
+pub struct TelemetryClient {
+    config: TelemetryConfig,
+    events: Vec<TelemetryEvent>,
+    base_url: String,
+    /// Whether telemetry level was forced via env var (skip prompts/nudges).
+    env_override: bool,
+    /// Path to the artifacts directory (for rich uploads).
+    artifacts_dir: Option<PathBuf>,
+}
+
+impl TelemetryClient {
+    /// Load telemetry state from disk or create a fresh config.
+    pub fn load_or_init() -> Self {
+        let env_override = std::env::var("DESKTEST_TELEMETRY").ok();
+        let base_url = std::env::var("DESKTEST_TELEMETRY_URL")
+            .unwrap_or_else(|_| DEFAULT_TELEMETRY_URL.to_string());
+
+        let mut config = load_config().unwrap_or_default();
+        let mut is_env_override = false;
+
+        if let Some(val) = env_override {
+            is_env_override = true;
+            config.consent_level = match val.as_str() {
+                "0" => ConsentLevel::None,
+                "1" => ConsentLevel::Anonymous,
+                "2" => ConsentLevel::Rich,
+                _ => ConsentLevel::None,
+            };
+        }
+
+        Self {
+            config,
+            events: Vec::new(),
+            base_url,
+            env_override: is_env_override,
+            artifacts_dir: None,
+        }
+    }
+
+    /// Check consent state: prompt on first run, nudge periodically.
+    /// Only call for test commands (run/suite/attach/interactive).
+    pub fn check_consent(&mut self) {
+        if self.env_override {
+            return;
+        }
+
+        // If stdin is not a TTY, skip prompting
+        if !atty::is(atty::Stream::Stdin) {
+            return;
+        }
+
+        if self.config.prompted_at.is_none() {
+            self.show_first_run_prompt();
+        } else if self.should_nudge() {
+            self.show_nudge();
+        }
+
+        self.config.run_count_since_prompt += 1;
+        let _ = save_config(&self.config);
+    }
+
+    /// Handle the `desktest telemetry <action>` subcommand.
+    pub fn handle_command(&mut self, action: &str) {
+        match action {
+            "off" => {
+                self.config.consent_level = ConsentLevel::None;
+                self.config.prompted_at = Some(now_iso8601());
+                self.config.run_count_since_prompt = 0;
+                let _ = save_config(&self.config);
+                eprintln!("Telemetry disabled.");
+            }
+            "anonymous" => {
+                self.config.consent_level = ConsentLevel::Anonymous;
+                self.config.prompted_at = Some(now_iso8601());
+                self.config.run_count_since_prompt = 0;
+                let _ = save_config(&self.config);
+                eprintln!("Telemetry set to anonymous (usage stats only).");
+            }
+            "rich" => {
+                self.config.consent_level = ConsentLevel::Rich;
+                self.config.prompted_at = Some(now_iso8601());
+                self.config.run_count_since_prompt = 0;
+                let _ = save_config(&self.config);
+                eprintln!("Telemetry set to rich (usage stats + trajectories & screenshots).");
+            }
+            "status" => {
+                println!("Telemetry status:");
+                println!("  Consent level:    {}", self.config.consent_level);
+                println!("  Install ID:       {}", self.config.install_id);
+                println!(
+                    "  Runs since prompt: {}",
+                    self.config.run_count_since_prompt
+                );
+                if let Some(ref ts) = self.config.prompted_at {
+                    println!("  Last prompted:    {ts}");
+                }
+            }
+            other => {
+                eprintln!(
+                    "Unknown telemetry action: '{other}'. Use: off, anonymous, rich, or status"
+                );
+                std::process::exit(2);
+            }
+        }
+    }
+
+    /// Record a telemetry event (stored in memory until flush).
+    pub fn record_event(&mut self, event: TelemetryEvent) {
+        if self.config.consent_level == ConsentLevel::None {
+            return;
+        }
+        self.events.push(event);
+    }
+
+    /// Set the artifacts directory for rich uploads.
+    pub fn set_artifacts_dir(&mut self, dir: PathBuf) {
+        self.artifacts_dir = Some(dir);
+    }
+
+    /// Current consent level.
+    pub fn consent_level(&self) -> ConsentLevel {
+        self.config.consent_level
+    }
+
+    /// Install ID for event creation.
+    pub fn install_id(&self) -> &str {
+        &self.config.install_id
+    }
+
+    /// Flush all queued events to the backend. Fire-and-forget with timeout.
+    pub async fn flush(&mut self) {
+        if self.config.consent_level == ConsentLevel::None || self.events.is_empty() {
+            return;
+        }
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/api/events", self.base_url);
+
+        // Send anonymous events
+        let events = std::mem::take(&mut self.events);
+        let send_result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client.post(&url).json(&events).send(),
+        )
+        .await;
+
+        match send_result {
+            Ok(Ok(resp)) => {
+                debug!("Telemetry events sent: status {}", resp.status());
+            }
+            Ok(Err(e)) => {
+                debug!("Telemetry send failed (ignored): {e}");
+            }
+            Err(_) => {
+                debug!("Telemetry send timed out (ignored)");
+            }
+        }
+
+        // Rich tier: upload artifacts tarball
+        if self.config.consent_level == ConsentLevel::Rich {
+            if let Some(ref artifacts_dir) = self.artifacts_dir {
+                if artifacts_dir.exists() {
+                    self.upload_artifacts(&client, artifacts_dir).await;
+                }
+            }
+        }
+    }
+
+    fn should_nudge(&self) -> bool {
+        if self.config.consent_level == ConsentLevel::Rich {
+            return false;
+        }
+        self.config.run_count_since_prompt > 0
+            && self.config.run_count_since_prompt % NUDGE_INTERVAL == 0
+    }
+
+    fn show_first_run_prompt(&mut self) {
+        eprintln!();
+        eprintln!("desktest would like to collect usage data to improve the tool.");
+        eprintln!();
+        eprintln!("  [1] Anonymous stats only \u{2014} test outcomes, duration, error types");
+        eprintln!("  [2] Rich diagnostics    \u{2014} also includes trajectories & screenshots");
+        eprintln!("  [n] No telemetry");
+        eprintln!();
+        eprintln!(
+            "API keys are NEVER collected. Learn more: https://github.com/Edison-Watch/desktest/wiki/telemetry"
+        );
+        eprintln!();
+        eprint!("Your choice [1/2/n]: ");
+
+        let mut input = String::new();
+        if std::io::stdin().read_line(&mut input).is_err() {
+            self.config.consent_level = ConsentLevel::None;
+        } else {
+            let trimmed = input.trim().to_lowercase();
+            self.config.consent_level = match trimmed.as_str() {
+                "1" => ConsentLevel::Anonymous,
+                "2" => ConsentLevel::Rich,
+                _ => ConsentLevel::None,
+            };
+        }
+
+        self.config.prompted_at = Some(now_iso8601());
+        self.config.run_count_since_prompt = 0;
+        let _ = save_config(&self.config);
+
+        match self.config.consent_level {
+            ConsentLevel::None => eprintln!("No telemetry. You can change this later with `desktest telemetry anonymous` or `desktest telemetry rich`."),
+            ConsentLevel::Anonymous => eprintln!("Thanks! Anonymous telemetry enabled. Change anytime with `desktest telemetry off`."),
+            ConsentLevel::Rich => eprintln!("Thanks! Rich telemetry enabled. Change anytime with `desktest telemetry off`."),
+        }
+        eprintln!();
+    }
+
+    fn show_nudge(&self) {
+        match self.config.consent_level {
+            ConsentLevel::None => {
+                eprintln!(
+                    "Tip: Help improve desktest \u{2014} run `desktest telemetry anonymous` to opt in"
+                );
+            }
+            ConsentLevel::Anonymous => {
+                eprintln!(
+                    "Tip: Share richer diagnostics with `desktest telemetry rich`"
+                );
+            }
+            ConsentLevel::Rich => {} // no nudge
+        }
+    }
+
+    async fn upload_artifacts(&self, client: &reqwest::Client, artifacts_dir: &std::path::Path) {
+        let tarball = match create_artifacts_tarball(artifacts_dir) {
+            Ok(data) => data,
+            Err(e) => {
+                debug!("Failed to create artifacts tarball: {e}");
+                return;
+            }
+        };
+
+        let url = format!("{}/api/upload", self.base_url);
+        let part = reqwest::multipart::Part::bytes(tarball)
+            .file_name("artifacts.tar.gz")
+            .mime_str("application/gzip")
+            .unwrap();
+
+        let form = reqwest::multipart::Form::new()
+            .text("install_id", self.config.install_id.clone())
+            .part("artifacts", part);
+
+        let send_result = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            client.post(&url).multipart(form).send(),
+        )
+        .await;
+
+        match send_result {
+            Ok(Ok(resp)) => {
+                debug!("Artifacts uploaded: status {}", resp.status());
+            }
+            Ok(Err(e)) => {
+                debug!("Artifacts upload failed (ignored): {e}");
+            }
+            Err(_) => {
+                debug!("Artifacts upload timed out (ignored)");
+            }
+        }
+    }
+}
+
+/// Build a TelemetryEvent with common fields pre-filled.
+pub fn build_event(client: &TelemetryClient, event_type: &str, command: &str) -> TelemetryEvent {
+    TelemetryEvent {
+        timestamp: now_iso8601(),
+        desktest_version: env!("CARGO_PKG_VERSION").to_string(),
+        install_id: client.install_id().to_string(),
+        event_type: event_type.to_string(),
+        app_type: None,
+        evaluator_mode: None,
+        provider: None,
+        model: None,
+        status: None,
+        duration_ms: None,
+        agent_steps: None,
+        error_category: None,
+        used_qa_mode: false,
+        used_replay: false,
+        used_bash: false,
+        platform: std::env::consts::OS.to_string(),
+        command: command.to_string(),
+    }
+}
+
+// --- Config persistence ---
+
+fn config_dir() -> Option<PathBuf> {
+    dirs_path().map(|p| {
+        let _ = std::fs::create_dir_all(&p);
+        p
+    })
+}
+
+fn dirs_path() -> Option<PathBuf> {
+    // Use XDG on Linux, ~/Library/Application Support on macOS
+    if cfg!(target_os = "macos") {
+        dirs_home().map(|h| h.join("Library/Application Support/desktest"))
+    } else {
+        std::env::var("XDG_CONFIG_HOME")
+            .ok()
+            .map(PathBuf::from)
+            .or_else(|| dirs_home().map(|h| h.join(".config")))
+            .map(|p| p.join("desktest"))
+    }
+}
+
+fn dirs_home() -> Option<PathBuf> {
+    std::env::var("HOME").ok().map(PathBuf::from)
+}
+
+fn state_file_path() -> Option<PathBuf> {
+    config_dir().map(|d| d.join(STATE_FILE_NAME))
+}
+
+fn load_config() -> Option<TelemetryConfig> {
+    let path = state_file_path()?;
+    let data = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+fn save_config(config: &TelemetryConfig) -> Result<(), std::io::Error> {
+    let path = match state_file_path() {
+        Some(p) => p,
+        None => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Cannot determine config directory",
+            ))
+        }
+    };
+    let json = serde_json::to_string_pretty(config)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    std::fs::write(&path, json)
+}
+
+fn now_iso8601() -> String {
+    // Use a simple approach without chrono
+    let duration = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("{}Z", duration.as_secs())
+}
+
+/// Create a gzipped tarball of the artifacts directory.
+/// Excludes potentially sensitive files (home directory contents, logs).
+fn create_artifacts_tarball(artifacts_dir: &std::path::Path) -> Result<Vec<u8>, std::io::Error> {
+    use flate2::write::GzEncoder;
+    use flate2::Compression;
+    use std::fs;
+
+    let buf = Vec::new();
+    let encoder = GzEncoder::new(buf, Compression::fast());
+    let mut archive = tar::Builder::new(encoder);
+
+    // Only include known safe file types
+    let allowed_extensions = ["jsonl", "json", "png", "jpg", "txt"];
+
+    if let Ok(entries) = fs::read_dir(artifacts_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let ext = path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            if !allowed_extensions.contains(&ext) {
+                continue;
+            }
+            let file_name = match path.file_name() {
+                Some(n) => n.to_string_lossy().to_string(),
+                None => continue,
+            };
+
+            // Redact home directory paths in file names (shouldn't happen, but safety)
+            let archive_name = file_name.replace(
+                &dirs_home()
+                    .map(|h| h.to_string_lossy().to_string())
+                    .unwrap_or_default(),
+                "~",
+            );
+
+            archive.append_path_with_name(&path, &archive_name)?;
+        }
+    }
+
+    let encoder = archive.into_inner()?;
+    encoder.finish()
+}
+
+/// Returns true if a CLI command is a test command that should trigger consent checks.
+pub fn is_test_command(command: &crate::cli::Command) -> bool {
+    matches!(
+        command,
+        crate::cli::Command::Run { .. }
+            | crate::cli::Command::Suite { .. }
+            | crate::cli::Command::Attach { .. }
+            | crate::cli::Command::Interactive { .. }
+    )
+}
+
+/// Extract the command name string for telemetry events.
+pub fn command_name(command: &crate::cli::Command) -> &'static str {
+    match command {
+        crate::cli::Command::Run { .. } => "run",
+        crate::cli::Command::Suite { .. } => "suite",
+        crate::cli::Command::Attach { .. } => "attach",
+        crate::cli::Command::Interactive { .. } => "interactive",
+        crate::cli::Command::Validate { .. } => "validate",
+        crate::cli::Command::Codify { .. } => "codify",
+        crate::cli::Command::Replay { .. } => "replay",
+        crate::cli::Command::Logs { .. } => "logs",
+        crate::cli::Command::Doctor => "doctor",
+        crate::cli::Command::Update { .. } => "update",
+        crate::cli::Command::Monitor { .. } => "monitor",
+        crate::cli::Command::Review { .. } => "review",
+        crate::cli::Command::Telemetry { .. } => "telemetry",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_consent_level_display() {
+        assert_eq!(ConsentLevel::None.to_string(), "none");
+        assert_eq!(ConsentLevel::Anonymous.to_string(), "anonymous");
+        assert_eq!(ConsentLevel::Rich.to_string(), "rich");
+    }
+
+    #[test]
+    fn test_config_serialization_roundtrip() {
+        let config = TelemetryConfig {
+            consent_level: ConsentLevel::Anonymous,
+            install_id: "test-uuid".to_string(),
+            prompted_at: Some("12345Z".to_string()),
+            run_count_since_prompt: 5,
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: TelemetryConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.consent_level, ConsentLevel::Anonymous);
+        assert_eq!(parsed.install_id, "test-uuid");
+        assert_eq!(parsed.run_count_since_prompt, 5);
+    }
+
+    #[test]
+    fn test_config_deserialization_from_json() {
+        let json = r#"{
+            "consent_level": "rich",
+            "install_id": "abc-123",
+            "prompted_at": "99999Z",
+            "run_count_since_prompt": 3
+        }"#;
+        let config: TelemetryConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.consent_level, ConsentLevel::Rich);
+        assert_eq!(config.install_id, "abc-123");
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = TelemetryConfig::default();
+        assert_eq!(config.consent_level, ConsentLevel::None);
+        assert!(!config.install_id.is_empty());
+        assert!(config.prompted_at.is_none());
+        assert_eq!(config.run_count_since_prompt, 0);
+    }
+
+    #[test]
+    fn test_should_nudge_logic() {
+        let mut client = TelemetryClient {
+            config: TelemetryConfig {
+                consent_level: ConsentLevel::None,
+                install_id: "test".to_string(),
+                prompted_at: Some("0Z".to_string()),
+                run_count_since_prompt: 0,
+            },
+            events: Vec::new(),
+            base_url: "http://localhost".to_string(),
+            env_override: false,
+            artifacts_dir: None,
+        };
+
+        // run_count 0 → no nudge
+        assert!(!client.should_nudge());
+
+        // run_count 10 → nudge
+        client.config.run_count_since_prompt = 10;
+        assert!(client.should_nudge());
+
+        // run_count 20 → nudge
+        client.config.run_count_since_prompt = 20;
+        assert!(client.should_nudge());
+
+        // run_count 5 → no nudge
+        client.config.run_count_since_prompt = 5;
+        assert!(!client.should_nudge());
+
+        // Rich consent → never nudge
+        client.config.consent_level = ConsentLevel::Rich;
+        client.config.run_count_since_prompt = 10;
+        assert!(!client.should_nudge());
+    }
+
+    #[test]
+    fn test_record_event_respects_consent() {
+        let mut client = TelemetryClient {
+            config: TelemetryConfig {
+                consent_level: ConsentLevel::None,
+                install_id: "test".to_string(),
+                prompted_at: None,
+                run_count_since_prompt: 0,
+            },
+            events: Vec::new(),
+            base_url: "http://localhost".to_string(),
+            env_override: false,
+            artifacts_dir: None,
+        };
+
+        let event = build_event(&client, "test_completed", "run");
+        client.record_event(event);
+        assert!(client.events.is_empty(), "Should not record when consent is None");
+
+        client.config.consent_level = ConsentLevel::Anonymous;
+        let event = build_event(&client, "test_completed", "run");
+        client.record_event(event);
+        assert_eq!(client.events.len(), 1);
+    }
+
+    #[test]
+    fn test_event_serialization() {
+        let event = TelemetryEvent {
+            timestamp: "12345Z".to_string(),
+            desktest_version: "0.12.0".to_string(),
+            install_id: "test-id".to_string(),
+            event_type: "test_completed".to_string(),
+            app_type: Some("appimage".to_string()),
+            evaluator_mode: None,
+            provider: Some("anthropic".to_string()),
+            model: Some("claude-sonnet-4-5-20250929".to_string()),
+            status: Some("pass".to_string()),
+            duration_ms: Some(5000),
+            agent_steps: Some(10),
+            error_category: None,
+            used_qa_mode: false,
+            used_replay: false,
+            used_bash: true,
+            platform: "linux".to_string(),
+            command: "run".to_string(),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("test_completed"));
+        assert!(json.contains("appimage"));
+        // None fields should be skipped
+        assert!(!json.contains("evaluator_mode"));
+        assert!(!json.contains("error_category"));
+    }
+
+    #[test]
+    fn test_build_event_fills_common_fields() {
+        let client = TelemetryClient {
+            config: TelemetryConfig {
+                consent_level: ConsentLevel::Anonymous,
+                install_id: "my-id".to_string(),
+                prompted_at: None,
+                run_count_since_prompt: 0,
+            },
+            events: Vec::new(),
+            base_url: "http://localhost".to_string(),
+            env_override: false,
+            artifacts_dir: None,
+        };
+
+        let event = build_event(&client, "test_completed", "run");
+        assert_eq!(event.install_id, "my-id");
+        assert_eq!(event.event_type, "test_completed");
+        assert_eq!(event.command, "run");
+        assert_eq!(event.desktest_version, env!("CARGO_PKG_VERSION"));
+        assert!(!event.timestamp.is_empty());
+    }
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -162,22 +162,34 @@ impl TelemetryClient {
                 self.config.consent_level = ConsentLevel::None;
                 self.config.prompted_at = Some(now_iso8601());
                 self.config.run_count_since_prompt = 0;
-                let _ = save_config(&self.config);
-                eprintln!("Telemetry disabled.");
+                if let Err(e) = save_config(&self.config) {
+                    eprintln!("Warning: could not save telemetry config: {e}");
+                    eprintln!("Your opt-out will not persist across runs.");
+                } else {
+                    eprintln!("Telemetry disabled.");
+                }
             }
             TelemetryAction::Anonymous => {
                 self.config.consent_level = ConsentLevel::Anonymous;
                 self.config.prompted_at = Some(now_iso8601());
                 self.config.run_count_since_prompt = 0;
-                let _ = save_config(&self.config);
-                eprintln!("Telemetry set to anonymous (usage stats only).");
+                if let Err(e) = save_config(&self.config) {
+                    eprintln!("Warning: could not save telemetry config: {e}");
+                    eprintln!("Your preference will not persist across runs.");
+                } else {
+                    eprintln!("Telemetry set to anonymous (usage stats only).");
+                }
             }
             TelemetryAction::Rich => {
                 self.config.consent_level = ConsentLevel::Rich;
                 self.config.prompted_at = Some(now_iso8601());
                 self.config.run_count_since_prompt = 0;
-                let _ = save_config(&self.config);
-                eprintln!("Telemetry set to rich (usage stats + trajectories & screenshots).");
+                if let Err(e) = save_config(&self.config) {
+                    eprintln!("Warning: could not save telemetry config: {e}");
+                    eprintln!("Your preference will not persist across runs.");
+                } else {
+                    eprintln!("Telemetry set to rich (usage stats + trajectories & screenshots).");
+                }
             }
             TelemetryAction::Status => {
                 println!("Telemetry status:");

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -120,7 +120,8 @@ impl TelemetryClient {
         }
 
         // If stdin is not a TTY, skip prompting
-        if !atty::is(atty::Stream::Stdin) {
+        use std::io::IsTerminal;
+        if !std::io::stdin().is_terminal() {
             return;
         }
 
@@ -316,7 +317,7 @@ impl TelemetryClient {
         let part = reqwest::multipart::Part::bytes(tarball)
             .file_name("artifacts.tar.gz")
             .mime_str("application/gzip")
-            .unwrap();
+            .expect("hardcoded MIME type is always valid");
 
         let form = reqwest::multipart::Form::new()
             .text("install_id", self.config.install_id.clone())
@@ -417,11 +418,32 @@ fn save_config(config: &TelemetryConfig) -> Result<(), std::io::Error> {
 }
 
 fn now_iso8601() -> String {
-    // Use a simple approach without chrono
     let duration = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
-    format!("{}Z", duration.as_secs())
+    let secs = duration.as_secs();
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86400;
+    let (y, mo, d) = epoch_days_to_ymd(days);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+/// Convert days since 1970-01-01 to (year, month, day).
+fn epoch_days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Algorithm from http://howardhinnant.github.io/date_algorithms.html
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let mo = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if mo <= 2 { y + 1 } else { y };
+    (y, mo, d)
 }
 
 /// Create a gzipped tarball of the artifacts directory.
@@ -457,12 +479,14 @@ fn create_artifacts_tarball(artifacts_dir: &std::path::Path) -> Result<Vec<u8>, 
             };
 
             // Redact home directory paths in file names (shouldn't happen, but safety)
-            let archive_name = file_name.replace(
-                &dirs_home()
-                    .map(|h| h.to_string_lossy().to_string())
-                    .unwrap_or_default(),
-                "~",
-            );
+            let home_str = dirs_home()
+                .map(|h| h.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let archive_name = if home_str.is_empty() {
+                file_name.clone()
+            } else {
+                file_name.replace(&home_str, "~")
+            };
 
             archive.append_path_with_name(&path, &archive_name)?;
         }
@@ -664,5 +688,32 @@ mod tests {
         assert_eq!(event.command, "run");
         assert_eq!(event.desktest_version, env!("CARGO_PKG_VERSION"));
         assert!(!event.timestamp.is_empty());
+    }
+
+    #[test]
+    fn test_now_iso8601_format() {
+        let ts = now_iso8601();
+        // Should match YYYY-MM-DDTHH:MM:SSZ
+        assert!(
+            ts.len() == 20,
+            "Expected 20-char ISO 8601, got {ts} (len {})",
+            ts.len()
+        );
+        assert!(ts.ends_with('Z'));
+        assert_eq!(&ts[4..5], "-");
+        assert_eq!(&ts[7..8], "-");
+        assert_eq!(&ts[10..11], "T");
+        assert_eq!(&ts[13..14], ":");
+        assert_eq!(&ts[16..17], ":");
+    }
+
+    #[test]
+    fn test_epoch_days_to_ymd_known_dates() {
+        // 1970-01-01 = day 0
+        assert_eq!(epoch_days_to_ymd(0), (1970, 1, 1));
+        // 2000-01-01 = day 10957
+        assert_eq!(epoch_days_to_ymd(10957), (2000, 1, 1));
+        // 2025-03-25 = day 20172
+        assert_eq!(epoch_days_to_ymd(20172), (2025, 3, 25));
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -251,8 +251,13 @@ impl TelemetryClient {
         if self.config.consent_level == ConsentLevel::Rich {
             return false;
         }
-        self.config.run_count_since_prompt > 0
-            && self.config.run_count_since_prompt % NUDGE_INTERVAL == 0
+        // Don't nudge users who explicitly opted out via `desktest telemetry off`
+        if self.config.consent_level == ConsentLevel::None && self.config.prompted_at.is_some() {
+            return false;
+        }
+        // +1 accounts for the increment that happens after this check in check_consent()
+        let next_count = self.config.run_count_since_prompt + 1;
+        next_count > 0 && next_count % NUDGE_INTERVAL == 0
     }
 
     fn show_first_run_prompt(&mut self) {
@@ -552,7 +557,7 @@ mod tests {
         let config = TelemetryConfig {
             consent_level: ConsentLevel::Anonymous,
             install_id: "test-uuid".to_string(),
-            prompted_at: Some("12345Z".to_string()),
+            prompted_at: Some("2025-03-25T10:13:20Z".to_string()),
             run_count_since_prompt: 5,
         };
 
@@ -569,7 +574,7 @@ mod tests {
         let json = r#"{
             "consent_level": "rich",
             "install_id": "abc-123",
-            "prompted_at": "99999Z",
+            "prompted_at": "2000-01-01T00:00:00Z",
             "run_count_since_prompt": 3
         }"#;
         let config: TelemetryConfig = serde_json::from_str(json).unwrap();
@@ -590,9 +595,9 @@ mod tests {
     fn test_should_nudge_logic() {
         let mut client = TelemetryClient {
             config: TelemetryConfig {
-                consent_level: ConsentLevel::None,
+                consent_level: ConsentLevel::Anonymous,
                 install_id: "test".to_string(),
-                prompted_at: Some("0Z".to_string()),
+                prompted_at: Some("2025-01-01T00:00:00Z".to_string()),
                 run_count_since_prompt: 0,
             },
             events: Vec::new(),
@@ -601,16 +606,20 @@ mod tests {
             artifacts_dir: None,
         };
 
-        // run_count 0 → no nudge
+        // run_count 0 → no nudge (next_count=1, 1%10!=0)
         assert!(!client.should_nudge());
 
-        // run_count 10 → nudge
-        client.config.run_count_since_prompt = 10;
+        // run_count 9 → nudge (next_count=10, 10%10==0)
+        client.config.run_count_since_prompt = 9;
         assert!(client.should_nudge());
 
-        // run_count 20 → nudge
-        client.config.run_count_since_prompt = 20;
+        // run_count 19 → nudge (next_count=20)
+        client.config.run_count_since_prompt = 19;
         assert!(client.should_nudge());
+
+        // run_count 10 → no nudge (next_count=11)
+        client.config.run_count_since_prompt = 10;
+        assert!(!client.should_nudge());
 
         // run_count 5 → no nudge
         client.config.run_count_since_prompt = 5;
@@ -618,7 +627,13 @@ mod tests {
 
         // Rich consent → never nudge
         client.config.consent_level = ConsentLevel::Rich;
-        client.config.run_count_since_prompt = 10;
+        client.config.run_count_since_prompt = 9;
+        assert!(!client.should_nudge());
+
+        // Explicit opt-out (None + prompted_at set) → never nudge
+        client.config.consent_level = ConsentLevel::None;
+        client.config.prompted_at = Some("2025-01-01T00:00:00Z".to_string());
+        client.config.run_count_since_prompt = 9;
         assert!(!client.should_nudge());
     }
 

--- a/telemetry-backend-agent-prompt.md
+++ b/telemetry-backend-agent-prompt.md
@@ -1,0 +1,268 @@
+# Desktest Telemetry Backend — Agent Prompt
+
+You are building an open-source telemetry backend for the **desktest** CLI tool. This is a new repository called `desktest-telemetry`. The backend receives anonymous usage stats and optional rich diagnostics (trajectories, screenshots) from desktest CLI users who opt in.
+
+## Project Setup
+
+- **Repo name:** `desktest-telemetry`
+- **Language:** Rust (edition 2024)
+- **Framework:** Axum 0.8
+- **Database:** PostgreSQL (via `sqlx` with compile-time checked queries)
+- **Object storage:** S3-compatible (Railway Storage Buckets, use `aws-sdk-s3` or `rust-s3`)
+- **Deployment target:** Railway.com Hobby plan ($5/mo)
+- **License:** MIT
+
+### Dependencies to use
+
+```toml
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+axum = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["limit", "cors"] }
+uuid = { version = "1", features = ["v4"] }
+chrono = { version = "0.4", features = ["serde"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+dotenvy = "0.15"
+aws-sdk-s3 = "1"
+aws-config = "1"
+```
+
+## Architecture
+
+```
+src/
+├── main.rs          # Axum server setup, router, startup
+├── routes/
+│   ├── mod.rs
+│   ├── events.rs    # POST /api/events
+│   ├── upload.rs    # POST /api/upload
+│   └── health.rs    # GET /api/health
+├── models.rs        # TelemetryEvent, Upload structs
+├── validation.rs    # Input validation (UUID, semver, enums)
+├── rate_limit.rs    # In-memory rate limiting (per-IP + per-install_id)
+├── storage.rs       # S3 bucket operations (upload, delete, size check)
+├── db.rs            # Database queries and pool setup
+└── cleanup.rs       # 90-day retention cleanup logic
+migrations/
+├── 001_create_events.sql
+└── 002_create_uploads.sql
+Dockerfile
+.env.example
+```
+
+## API Endpoints
+
+### `GET /api/health`
+- Returns `200 OK` with `{"status": "ok"}`
+- Used by Railway health checks
+
+### `POST /api/events`
+- **Purpose:** Receive batched anonymous telemetry events
+- **Content-Type:** `application/json`
+- **Max body size:** 64KB (enforced by tower-http `RequestBodyLimitLayer`)
+- **Request body:**
+```json
+{
+  "events": [
+    {
+      "timestamp": "2026-03-24T14:32:45Z",
+      "desktest_version": "0.12.1",
+      "install_id": "550e8400-e29b-41d4-a716-446655440000",
+      "event_type": "test_completed",
+      "command": "run",
+      "app_type": "appimage",
+      "evaluator_mode": "hybrid",
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-5-20250929",
+      "status": "pass",
+      "duration_ms": 45230,
+      "agent_steps": 7,
+      "error_category": null,
+      "used_qa": false,
+      "used_replay": false,
+      "used_bash": false,
+      "platform": "darwin"
+    }
+  ]
+}
+```
+- **Validation rules (reject 400 if any fail):**
+  - `install_id`: valid UUID v4 format
+  - `desktest_version`: matches `\d+\.\d+\.\d+`
+  - `event_type`: one of `test_completed`, `suite_completed`, `error`
+  - `command`: one of `run`, `suite`, `attach`, `interactive`
+  - `events` array: max 100 items per batch
+- **Response:** `200 OK` on success, `400 Bad Request` on validation failure, `503 Service Unavailable` if storage cap exceeded
+
+### `POST /api/upload`
+- **Purpose:** Receive rich diagnostic tarballs (trajectories, screenshots)
+- **Content-Type:** `multipart/form-data`
+- **Max body size:** 50MB
+- **Headers:**
+  - `X-Install-Id`: UUID v4 (required)
+  - `X-Run-Id`: UUID v4 (required)
+- **Body:** Single file field named `archive` containing a `.tar.gz`
+- **Validation:**
+  - Both headers must be valid UUID v4
+  - File must have `.tar.gz` extension
+  - File size must be under 50MB
+- **Behavior:**
+  1. Upload tarball to S3 bucket at key `{install_id}/{run_id}.tar.gz`
+  2. Insert metadata row into `uploads` table with `expires_at = NOW() + 90 days`
+- **Response:** `200 OK` with `{"key": "..."}`, `400`/`503` on error
+
+## Database Schema
+
+```sql
+-- migrations/001_create_events.sql
+CREATE TABLE events (
+    id SERIAL PRIMARY KEY,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    install_id TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    desktest_version TEXT,
+    event_type TEXT NOT NULL,
+    command TEXT,
+    app_type TEXT,
+    evaluator_mode TEXT,
+    provider TEXT,
+    model TEXT,
+    status TEXT,
+    duration_ms BIGINT,
+    agent_steps INT,
+    error_category TEXT,
+    used_qa BOOLEAN,
+    used_replay BOOLEAN,
+    used_bash BOOLEAN,
+    platform TEXT
+);
+
+CREATE INDEX idx_events_install_id ON events(install_id);
+CREATE INDEX idx_events_received_at ON events(received_at);
+
+-- migrations/002_create_uploads.sql
+CREATE TABLE uploads (
+    id SERIAL PRIMARY KEY,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    install_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    bucket_key TEXT NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX idx_uploads_expires_at ON uploads(expires_at);
+CREATE INDEX idx_uploads_install_id ON uploads(install_id);
+```
+
+## Rate Limiting
+
+Implement in-memory rate limiting (no external dependency like Redis needed at this scale).
+
+**Per-IP limits:**
+- `/api/events`: 60 requests/minute
+- `/api/upload`: 10 requests/minute
+
+**Per-install_id limits:**
+- Events: 100 events/day (across all batches)
+- Uploads: 50 uploads/day
+
+**Implementation:** Use a `DashMap<String, (u32, Instant)>` or similar concurrent map. Clean up stale entries periodically (every 5 minutes via tokio::spawn background task). Return `429 Too Many Requests` when limits exceeded.
+
+## Storage Hard Caps (Circuit Breaker)
+
+Prevent cost runaway even under sustained attack:
+
+| Resource | Hard Cap | Estimated Max Cost |
+|----------|----------|-------------------|
+| PostgreSQL `events` table | 1GB (~5M rows) | $0.25/mo |
+| S3 bucket total size | 100GB | $1.50/mo |
+
+**Implementation:**
+- Cache the current size estimate (refresh every 5 minutes via background task)
+- For Postgres: `SELECT pg_total_relation_size('events')`
+- For S3: maintain a running total in an `atomic u64` updated on each upload, periodically reconciled with actual bucket size
+- When cap is reached, return `503 Service Unavailable` with body `{"error": "storage_cap_exceeded"}`
+
+## 90-Day Retention Cleanup
+
+Implement as a function callable from:
+1. A background tokio task that runs once daily
+2. A `POST /api/cleanup` endpoint (protected by a shared secret env var `CLEANUP_SECRET`) for manual triggering
+
+**Cleanup logic:**
+```
+1. SELECT id, bucket_key FROM uploads WHERE expires_at < NOW() LIMIT 1000
+2. For each: delete S3 object, then delete DB row
+3. Repeat until no more expired rows
+4. Optional: DELETE FROM events WHERE received_at < NOW() - INTERVAL '1 year'
+```
+
+## Environment Variables
+
+```env
+# .env.example
+DATABASE_URL=postgres://user:pass@host:5432/desktest_telemetry
+AWS_ENDPOINT_URL=https://your-bucket.railway.app  # Railway S3-compatible endpoint
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+S3_BUCKET_NAME=desktest-telemetry
+CLEANUP_SECRET=some-random-secret
+PORT=8080
+RUST_LOG=info
+```
+
+## Dockerfile
+
+```dockerfile
+FROM rust:1.87-slim AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY src/ src/
+COPY migrations/ migrations/
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/desktest-telemetry /usr/local/bin/
+EXPOSE 8080
+CMD ["desktest-telemetry"]
+```
+
+## Implementation Order
+
+1. **Scaffold project** — `cargo init`, add dependencies, create directory structure
+2. **Database setup** — `db.rs` with sqlx pool, migration files
+3. **Models + validation** — `models.rs`, `validation.rs` with all the rules above
+4. **Health endpoint** — `GET /api/health` (proves server runs)
+5. **Events endpoint** — `POST /api/events` with validation + DB insert
+6. **Rate limiting** — `rate_limit.rs` middleware, wire into router
+7. **Upload endpoint** — `POST /api/upload` with S3 storage
+8. **Storage caps** — Background task for size monitoring, circuit breaker logic
+9. **Cleanup** — 90-day retention cleanup task + manual endpoint
+10. **Dockerfile** — Build and test locally with `docker compose` (Postgres + app)
+11. **Deploy to Railway** — Push, configure env vars, add Postgres plugin + Storage Bucket
+
+## Testing
+
+- Unit tests for validation logic (UUID format, semver, enum matching)
+- Unit tests for rate limit counter logic
+- Integration tests with a test Postgres database (use `sqlx::test` or testcontainers)
+- Integration test for the full `/api/events` flow (valid + invalid payloads)
+- Integration test for `/api/upload` (mock S3 or use local MinIO)
+- Test that oversized payloads are rejected before processing
+- Test that rate limits return 429
+- Test that storage cap returns 503
+
+## Key Design Decisions
+
+- **No authentication** — This is anonymous telemetry. Rate limits + caps are sufficient. An API key adds management overhead for no real security benefit.
+- **Batch events** — The CLI sends all events for a run in a single POST, reducing round trips.
+- **Fail-open on the CLI side** — If the backend is down, the CLI silently drops events. Telemetry must never break the user's workflow.
+- **S3 for blobs, Postgres for metadata** — S3 bucket egress is free on Railway, making it ideal for large files. Postgres handles structured queries efficiently.
+- **In-memory rate limiting** — At this scale (single instance), no need for Redis. A concurrent hashmap is sufficient and adds zero operational overhead.


### PR DESCRIPTION
## Summary
- Adds a complete CLI-side telemetry system with two opt-in tiers: **anonymous** (usage stats: test outcomes, duration, error types) and **rich** (also includes trajectories & screenshots as tarball upload)
- Consent managed via first-run interactive prompt, `desktest telemetry` subcommand (`off`/`anonymous`/`rich`/`status`), and `DESKTEST_TELEMETRY` env var override for CI
- Events are fire-and-forget (5s timeout for stats, 30s for artifact uploads) to a configurable endpoint (`DESKTEST_TELEMETRY_URL`), failing silently — no user impact if backend is unreachable
- Non-interactive detection (stdin not TTY) skips prompts, periodic nudges every 10 runs for non-rich users

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo test` — all 414 existing + 7 new telemetry unit tests pass
- [x] `desktest telemetry status` — shows consent level, install ID, run count
- [x] `desktest telemetry anonymous` / `desktest telemetry off` — toggles work correctly
- [x] `DESKTEST_TELEMETRY=1 desktest telemetry status` — env override applies
- [ ] First-run prompt on fresh install (delete state file, run `desktest run task.json`)
- [ ] Nudge appears at 10th run (set `run_count_since_prompt: 9` in state file)
- [ ] Non-interactive: `echo "" | desktest run task.json` — no prompt (stdin not TTY)
- [ ] Fire-and-forget: with `anonymous` consent, run completes without hang/error even with no backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
