### PR TITLE
fix: use green badge for evaluation_passed

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -175,7 +175,7 @@ if (HAS_RECORDING) {
 function badgeClass(result) {
   if (!result) return 'fail';
   if (result === 'success') return 'success';
-  if (result === 'evaluation_passed') return 'done';
+  if (result === 'evaluation_passed') return 'pass';
   if (result === 'done') return 'done';
   if (result.startsWith('error') || result === 'fail' || result === 'evaluation_error') return 'error';
   if (result === 'evaluation_failed') return 'fail';


### PR DESCRIPTION
## Summary
- Changed `evaluation_passed` badge from blue (`done` class) to green (`pass` class) in the dashboard UI
- Ensures red is only used for errors/failures, and green clearly indicates success

## Test plan
- [ ] Run `desktest run` with `--monitor` in deterministic/replay mode, verify `evaluation_passed` badge is green
- [ ] Run `desktest review` on artifacts from a passing deterministic test, verify green badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
