### PR TITLE
fix: reserve red badge color for errors only

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -177,9 +177,10 @@ function badgeClass(result) {
   if (result === 'success') return 'success';
   if (result === 'evaluation_passed') return 'done';
   if (result === 'done') return 'done';
+  if (result === 'timeout' || result === 'max_steps' || result === 'interrupted') return 'done';
   if (result.startsWith('error') || result === 'fail' || result === 'evaluation_error') return 'error';
   if (result === 'evaluation_failed') return 'fail';
-  return 'fail';
+  return 'done';
 }
 
 var VALID_ACTION_TYPES = {'python': true, 'bash': true, 'python + bash': true, 'python+bash': true};


### PR DESCRIPTION
## Summary
- Added explicit `badgeClass` handling for `timeout`, `max_steps`, and `interrupted` results → blue (`done`) instead of falling through to red
- Changed the default fallthrough from `fail` (red) to `done` (blue) so only explicitly error/fail results render in red
- Red is now reserved exclusively for `error:*`, `fail`, `evaluation_error`, and `evaluation_failed`

## Test plan
- [ ] Run `desktest run --replay` with `--monitor`, verify `evaluation_passed` badge is blue
- [ ] Run `desktest review` on replay artifacts, verify non-error results don't show red
- [ ] Verify `evaluation_failed` and `error:*` results still show red

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
