### PR TITLE
docs: improve README readability and sync with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ cd desktest
 make install_cli
 ```
 
+## Main Commands
+
 <details>
-<summary><strong>Main Commands</strong></summary>
+<summary>Expand</summary>
 
 ```bash
 # Validate a task file
@@ -145,9 +147,10 @@ Options:
   --api-key <KEY>            API key for the LLM provider (prefer env vars to avoid shell history exposure)
 ```
 
-<a id="task-definition"></a>
+## Task Definition
+
 <details>
-<summary><strong>Task Definition</strong></summary>
+<summary>Expand</summary>
 
 Tests are defined in JSON files. Here's a complete example that tests a calculator app:
 
@@ -240,8 +243,10 @@ When `--qa` is enabled:
 - The agent continues its task after reporting — multiple bugs can be found per run
 - Bug count is included in `results.json` and the test output
 
+## Architecture
+
 <details>
-<summary><strong>Architecture</strong></summary>
+<summary>Expand</summary>
 
 ```
 Developer writes task.json
@@ -280,8 +285,10 @@ Developer writes task.json
 
 </details>
 
+## Artifacts
+
 <details>
-<summary><strong>Artifacts</strong></summary>
+<summary>Expand</summary>
 
 Each test run produces:
 
@@ -311,8 +318,10 @@ desktest_artifacts/
 | 3 | Infrastructure error |
 | 4 | Agent error |
 
+## Environment Variables
+
 <details>
-<summary><strong>Environment Variables</strong></summary>
+<summary>Expand</summary>
 
 | Variable | Description |
 |----------|-------------|


### PR DESCRIPTION
## Summary
- Group features into categories (Testing & Execution, Observability & Debugging, Extensibility)
- Wrap verbose reference sections (Architecture, Task Definition, Artifacts, Env Vars, Main Commands) in collapsible `<details>` tags
- Sync CLI section with current `desktest --help` output — adds missing commands (`monitor`, `update`) and options (`--resolution`, `--artifacts-dir`, `--provider`, `--model`, `--api-key`)
- Add missing environment variables (`OPENROUTER_API_KEY`, `CEREBRAS_API_KEY`, `GEMINI_API_KEY`, `GITHUB_TOKEN`)
- Add inline comments to task JSON example and `(always)`/`(with --flag)` annotations to artifacts
- Remove legacy CLI section

## Test plan
- [ ] Verify collapsible sections render correctly on GitHub
- [ ] Confirm all CLI commands/options match `desktest --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
