### PR TITLE
fix: backfill action_code for older replay scripts

### DIFF
--- a/src/evaluator/script.rs
+++ b/src/evaluator/script.rs
@@ -95,7 +95,10 @@ pub(super) async fn evaluate_script_replay(
     // Backfill action codes from the script source for older replay scripts
     // that don't emit REPLAY_ACTION markers.
     if steps.iter().any(|s| s.action_code.is_none()) {
-        let script_source = std::fs::read_to_string(host_path).unwrap_or_default();
+        let script_source = std::fs::read_to_string(host_path).unwrap_or_else(|e| {
+            warn!("Failed to read script source for action-code backfill: {e}");
+            String::new()
+        });
         let fallback_codes = extract_action_codes_from_script(&script_source);
         for step in &mut steps {
             if step.action_code.is_none() {


### PR DESCRIPTION
## Summary
- Older replay scripts (generated before `REPLAY_ACTION` markers were added) produce empty `action_code` in the trajectory, so the review frontend only shows thoughts with no code
- Adds a fallback in `evaluate_script_replay` that parses the Python script source to extract action code from `def step_NNN():` function bodies when `REPLAY_ACTION` markers are missing
- Handles single/multi-line docstrings, screenshot comparison boilerplate, and standard codify indentation

## Test plan
- [x] All 454 existing tests pass
- [x] 5 new unit tests for `extract_action_codes_from_script` covering: basic extraction, multi-line docstrings, screenshot assertion skipping, empty scripts, and non-step scripts
- [ ] Manual: run `desktest --replay` with an older script (no `REPLAY_ACTION` markers) and verify action code appears in review HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
