### PR TITLE
fix: write results.json before artifact collection

### DIFF
--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -297,13 +297,9 @@ pub(crate) async fn run_task(
         r = run_task_inner(&ctx, run.clone(), monitor.as_ref(), start, Some(&redactor)) => r,
     };
 
-    // Collect artifacts (with timeout) and clean up
-    maybe_collect_artifacts(&session, &artifacts_dir, &run).await;
-
-    info!("Cleaning up container...");
-    let _ = session.cleanup().await;
-
-    finalize_run(
+    // Write results.json BEFORE artifact collection so the evaluation outcome
+    // is persisted even if artifact collection hangs and the process is killed.
+    let outcome = finalize_run(
         result,
         &task_def,
         &artifacts_dir,
@@ -311,7 +307,15 @@ pub(crate) async fn run_task(
         start,
         run.qa,
         Some(&redactor),
-    )
+    );
+
+    // Collect artifacts (with timeout) and clean up
+    maybe_collect_artifacts(&session, &artifacts_dir, &run).await;
+
+    info!("Cleaning up container...");
+    let _ = session.cleanup().await;
+
+    outcome
 }
 
 /// Shared post-inner logic: save task.json, write results.json, map to outcome.
@@ -1032,10 +1036,9 @@ pub(crate) async fn run_attach(
         r = run_attach_inner(&ctx, run.clone(), monitor.as_ref(), start, Some(&redactor)) => r,
     };
 
-    // Collect artifacts but do NOT clean up the container (we don't own it)
-    maybe_collect_artifacts(&session, &artifacts_dir, &run).await;
-
-    finalize_run(
+    // Write results.json BEFORE artifact collection so the evaluation outcome
+    // is persisted even if artifact collection hangs and the process is killed.
+    let outcome = finalize_run(
         result,
         &task_def,
         &artifacts_dir,
@@ -1043,7 +1046,12 @@ pub(crate) async fn run_attach(
         start,
         run.qa,
         Some(&redactor),
-    )
+    );
+
+    // Collect artifacts but do NOT clean up the container (we don't own it)
+    maybe_collect_artifacts(&session, &artifacts_dir, &run).await;
+
+    outcome
 }
 
 /// Inner logic for attach mode: run setup steps, agent loop, and evaluation.


### PR DESCRIPTION
## Summary

- Moves `finalize_run()` (results.json writing) **before** `maybe_collect_artifacts()` in both `run_task` and `run_attach` flows
- Fixes issue where evaluation results were lost when artifact collection hung and the process was killed (exit 137/124), causing CI to treat passed tests as failures

## Context

When `desktest attach` artifact collection hangs (e.g., large file copy), the process may be killed by an OOM killer (exit 137) or timeout wrapper (exit 124). The evaluation had already passed, but `results.json` was never written because it happened after artifact collection. CI pipelines treating any non-zero exit as failure would abort despite the test passing.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` — 464 passed, 0 failed
- [ ] Manual: run `desktest attach` with a task that passes evaluation, verify `results.json` exists even if artifact collection is interrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
