### PR TITLE
fix: increase test timeouts for flaky tart::protocol tests

### DIFF
--- a/src/tart/protocol.rs
+++ b/src/tart/protocol.rs
@@ -235,7 +235,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let client = ProtocolClient::with_timeouts(
             temp.path(),
-            Duration::from_secs(2),
+            Duration::from_secs(10),
             Duration::from_millis(25),
         );
         client.ensure_layout().await.unwrap();
@@ -284,7 +284,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let client = ProtocolClient::with_timeouts(
             temp.path(),
-            Duration::from_secs(2),
+            Duration::from_secs(10),
             Duration::from_millis(25),
         );
         client.ensure_layout().await.unwrap();
@@ -330,7 +330,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let client = ProtocolClient::with_timeouts(
             temp.path(),
-            Duration::from_secs(2),
+            Duration::from_secs(10),
             Duration::from_millis(25),
         );
         client.ensure_layout().await.unwrap();
@@ -474,7 +474,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let client = ProtocolClient::with_timeouts(
             temp.path(),
-            Duration::from_secs(2),
+            Duration::from_secs(10),
             Duration::from_millis(25),
         );
         client.ensure_layout().await.unwrap();


### PR DESCRIPTION
## Summary
- Increased test-only `send_request` timeout from 2s to 10s across four `tart::protocol` tests that were intermittently timing out in CI (Coverage and Release workflows)
- Root cause: filesystem polling races under CI load (coverage instrumentation, shared runners) caused the background task to write the response file after the 2s deadline
- Production `DEFAULT_REQUEST_TIMEOUT` (30s) is unchanged

## Test plan
- [x] `cargo test tart::protocol` passes locally (9/9, ~0.13s)
- [ ] CI Coverage workflow passes without timeout flakes
- [ ] CI Release workflow passes without timeout flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)