### PR TITLE
fix: decouple agent loop execution from evaluator mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -264,6 +264,11 @@ async fn main() {
             }
 
             if *replay {
+                if cli.provider.is_some() {
+                    eprintln!(
+                        "Warning: --provider is ignored in --replay mode (replay runs are deterministic, no LLM is used)"
+                    );
+                }
                 if let Err(e) = task_def.apply_replay_override() {
                     eprintln!("Error: {e}");
                     std::process::exit(e.exit_code());
@@ -276,7 +281,7 @@ async fn main() {
                 &llm_overrides(&cli),
             );
 
-            let needs_llm = !*replay && !task_def.is_programmatic_only();
+            let needs_llm = !task_def.replay_mode && !task_def.is_programmatic_only();
             if let Err(e) =
                 preflight::run_preflight(&run_config, needs_llm, Some(&task_def.app)).await
             {
@@ -397,6 +402,11 @@ async fn main() {
             }
 
             if *replay {
+                if cli.provider.is_some() {
+                    eprintln!(
+                        "Warning: --provider is ignored in --replay mode (replay runs are deterministic, no LLM is used)"
+                    );
+                }
                 if let Err(e) = task_def.apply_replay_override() {
                     eprintln!("Error: {e}");
                     std::process::exit(e.exit_code());
@@ -409,7 +419,7 @@ async fn main() {
                 &llm_overrides(&cli),
             );
 
-            let needs_llm = !*replay && !task_def.is_programmatic_only();
+            let needs_llm = !task_def.replay_mode && !task_def.is_programmatic_only();
             if let Err(e) =
                 preflight::run_preflight(&run_config, needs_llm, Some(&task_def.app)).await
             {

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -685,9 +685,13 @@ async fn run_eval_loop(
         }
     };
 
-    match eval_mode {
-        EvaluatorMode::Programmatic => {
-            info!("Programmatic mode: skipping agent loop, running evaluation...");
+    // Replay mode: skip the agent loop entirely — just run programmatic evaluation.
+    // Non-replay programmatic mode: run the agent loop, then evaluate programmatically.
+    let skip_agent = task_def.replay_mode;
+
+    match (eval_mode, skip_agent) {
+        (EvaluatorMode::Programmatic, true) => {
+            info!("Replay mode: skipping agent loop, running evaluation...");
 
             let evaluator = task_def.evaluator.as_ref().expect(
                 "Programmatic mode requires evaluator config (validated at task load time)",
@@ -875,7 +879,56 @@ async fn run_eval_loop(
                 agent_ran: false,
             })
         }
-        EvaluatorMode::Llm => {
+        (EvaluatorMode::Programmatic, false) => {
+            // Non-replay programmatic: run the agent loop, then evaluate with
+            // programmatic metrics only (agent self-assessment is ignored).
+            info!("Starting agent loop v2 (programmatic evaluation after agent)...");
+            let agent_loop_result =
+                run_agent_loop(ctx, run, recording.as_ref(), monitor, redactor).await;
+
+            if let Some(rec) = &recording {
+                rec.stop(session).await;
+                rec.collect(session, artifacts_dir).await;
+            }
+
+            let agent_outcome = agent_loop_result?;
+
+            info!("Agent loop complete, running programmatic evaluation...");
+            let evaluator = task_def
+                .evaluator
+                .as_ref()
+                .expect("Programmatic mode requires evaluator config (validated at task load time)");
+            let eval_result = evaluator::run_evaluation(session, evaluator, artifacts_dir).await?;
+
+            print_validation_results(Some(&agent_outcome), Some(&eval_result));
+
+            if let Some(m) = monitor {
+                m.send(monitor::MonitorEvent::TestComplete {
+                    test_id: task_def.id.clone(),
+                    passed: eval_result.passed,
+                    reasoning: format_evaluation_reasoning(
+                        Some(&agent_outcome),
+                        Some(&eval_result),
+                    ),
+                    duration_ms: start_time.elapsed().as_millis() as u64,
+                });
+            }
+
+            Ok(TaskRunResult {
+                outcome: AgentOutcome {
+                    passed: eval_result.passed,
+                    reasoning: format_evaluation_reasoning(
+                        Some(&agent_outcome),
+                        Some(&eval_result),
+                    ),
+                    screenshot_count: agent_outcome.screenshot_count,
+                    bugs_found: agent_outcome.bugs_found,
+                },
+                eval_result: Some(eval_result),
+                agent_ran: true,
+            })
+        }
+        (EvaluatorMode::Llm, _) => {
             info!("Starting agent loop v2 (LLM-only evaluation)...");
             let agent_loop_result =
                 run_agent_loop(ctx, run, recording.as_ref(), monitor, redactor).await;
@@ -894,7 +947,7 @@ async fn run_eval_loop(
                 agent_ran: true,
             })
         }
-        EvaluatorMode::Hybrid => {
+        (EvaluatorMode::Hybrid, _) => {
             info!("Starting agent loop v2 (hybrid evaluation)...");
             let agent_loop_result =
                 run_agent_loop(ctx, run, recording.as_ref(), monitor, redactor).await;

--- a/src/task.rs
+++ b/src/task.rs
@@ -82,6 +82,12 @@ pub struct TaskDefinition {
     /// The normal evaluator still runs afterward to determine the final verdict.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub early_exit: Option<EarlyExitConfig>,
+
+    /// Internal flag: set by `apply_replay_override()` to indicate this task is
+    /// in deterministic replay mode (no agent loop, just programmatic evaluation).
+    /// Not serialized — this is runtime-only state.
+    #[serde(skip)]
+    pub(crate) replay_mode: bool,
 }
 
 fn default_timeout() -> u64 {
@@ -591,6 +597,8 @@ impl TaskDefinition {
             AppError::Config("--replay requires a 'replay_script' path in the task JSON".into())
         })?;
 
+        self.replay_mode = true;
+
         let replay_metric = MetricConfig::ScriptReplay {
             script_path,
             screenshots_dir: self.replay_screenshots_dir.clone(),
@@ -689,11 +697,18 @@ impl TaskDefinition {
         Ok(())
     }
 
-    /// Returns true if this task uses programmatic-only evaluation (no LLM agent loop).
+    /// Returns true if this task needs no LLM agent loop at all.
+    ///
+    /// Only true in replay mode — the agent loop is skipped entirely and only
+    /// programmatic evaluation runs. Non-replay tasks with a `Programmatic`
+    /// evaluator still run the agent loop; the evaluator mode only controls
+    /// how success is measured.
     pub fn is_programmatic_only(&self) -> bool {
-        self.evaluator
-            .as_ref()
-            .is_some_and(|e| matches!(e.mode, EvaluatorMode::Programmatic))
+        self.replay_mode
+            && self
+                .evaluator
+                .as_ref()
+                .is_some_and(|e| matches!(e.mode, EvaluatorMode::Programmatic))
     }
 
     /// Build the full instruction string, appending the completion condition if present.


### PR DESCRIPTION
## Summary
- **`--replay` + `--provider` footgun**: Now emits a warning that `--provider` is ignored in replay mode, since replay runs are deterministic and don't use an LLM.
- **Programmatic evaluator skipping agent loop**: `EvaluatorMode::Programmatic` no longer unconditionally skips the agent loop. A new `replay_mode` flag on `TaskDefinition` tracks whether `--replay` was used — only replay mode skips the agent. Non-replay tasks with programmatic evaluators now run the agent loop, then evaluate with programmatic metrics only (no need for the `"hybrid"` workaround).
- Updated `is_programmatic_only()` so non-replay programmatic tasks correctly require LLM provider validation.

## Test plan
- [x] All 521 existing tests pass
- [ ] `desktest run task.json --replay` — agent loop skipped, programmatic eval runs (unchanged behavior)
- [ ] `desktest run task.json --replay --provider claude-cli` — warning printed, replay still runs
- [ ] `desktest attach --provider claude-cli --container X` with `"evaluator": {"mode": "programmatic"}` — agent loop now runs, then programmatic eval determines pass/fail
- [ ] `desktest run task.json --provider claude-cli` with programmatic evaluator — agent loop runs, programmatic eval only

🤖 Generated with [Claude Code](https://claude.com/claude-code)