### PR TITLE
docs: add multi-app example to examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,6 +47,15 @@ desktest run examples/electron-todo.json
 
 See [ELECTRON_QUICKSTART.md](ELECTRON_QUICKSTART.md) for a complete guide to testing Electron apps.
 
+### `multi-app-terminal-gedit.json` — Multi-App Workflow (Hard)
+
+A harder test that exercises multi-app coordination: curl a CSV from a local HTTP server in a terminal, open it in gedit, find-and-replace ERROR→FIXED, save, and verify with grep. Tests app switching, dialog navigation, terminal interaction, and multi-step evaluation (4 metrics).
+
+```bash
+desktest run examples/multi-app-terminal-gedit.json
+desktest run examples/multi-app-terminal-gedit.json --monitor
+```
+
 ### `macos-textedit.json` — macOS TextEdit (Tart VM)
 
 Tests basic text editing on macOS inside a Tart VM. Requires Apple Silicon, Tart, and a golden image prepared with `desktest init-macos`.


### PR DESCRIPTION
## Summary
- Adds the `multi-app-terminal-gedit.json` example entry to `examples/README.md`
- This example was added in PR #89 but the README wasn't updated

## Test plan
- [x] Verified all other examples are still listed
- [x] New entry accurately describes the multi-app workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)