### PR TITLE
fix: increase protocol test timeouts to prevent flaky CI

### DIFF
--- a/src/tart/protocol.rs
+++ b/src/tart/protocol.rs
@@ -235,7 +235,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let client = ProtocolClient::with_timeouts(
             temp.path(),
-            Duration::from_secs(10),
+            Duration::from_secs(30),
             Duration::from_millis(25),
         );
         client.ensure_layout().await.unwrap();
@@ -284,7 +284,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let client = ProtocolClient::with_timeouts(
             temp.path(),
-            Duration::from_secs(10),
+            Duration::from_secs(30),
             Duration::from_millis(25),
         );
         client.ensure_layout().await.unwrap();
@@ -330,7 +330,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let client = ProtocolClient::with_timeouts(
             temp.path(),
-            Duration::from_secs(10),
+            Duration::from_secs(30),
             Duration::from_millis(25),
         );
         client.ensure_layout().await.unwrap();


### PR DESCRIPTION
## Summary
- Three Tart protocol tests (`send_request_reads_response_file`, `send_request_returns_error_on_malformed_response`, `send_request_returns_agent_error_when_error_field_set`) used a 10s request timeout
- Under `cargo tarpaulin` instrumentation in CI, the spawned background tasks that write response files can be slow enough to exceed 10s, causing spurious "Timed out waiting for Tart response" failures
- Bumped timeouts from 10s to 30s — these tests verify response parsing behavior, not timeout behavior, so a generous timeout only improves reliability

## Test plan
- [x] `cargo test tart::protocol::tests` — all 9 tests pass
- [ ] CI coverage job should no longer flake on `send_request_returns_error_on_malformed_response`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
