### PR TITLE
ui: move version below banner frame, update tagline

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn print_banner(version: &str) -> usize {
     // Tagline inside box (without version), version goes below
     let tagline_inside = " Desktest CLI \u{2014} Computer-use CLI for scalable E2E desktop testing";
     let tagline_inside_len = tagline_inside.chars().count();
-    let version_line = format!(" v{version}");
+    let version_line = format!("v{version}");
     // Inner width = max of all content lines (logo + tagline) + 2 for left/right padding
     let max_logo = LOGO_LINES
         .iter()
@@ -112,8 +112,8 @@ fn print_banner(version: &str) -> usize {
     // Bottom border: half-height bar (▀ = upper half block, hugs content)
     println!("{CYAN}{}{RESET}", "▀".repeat(box_width));
 
-    // Version below the box
-    println!(" {GREY}{version_line}{RESET}");
+    // Version below the box (2-space indent aligns with box interior content)
+    println!("  {GREY}{version_line}{RESET}");
 
     println!();
     box_width


### PR DESCRIPTION
## Summary
- Move version number and commit hash below the cyan banner frame (no longer inside the box)
- Keep "Desktest CLI" tagline inside the frame
- Update tagline from "Playwright for full-computer tests" to "Computer-use CLI for scalable E2E desktop testing"

## Test plan
- [ ] Run `desktest` with no args and verify banner renders correctly with version below frame
- [ ] Verify tagline appears inside the cyan box

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
