### PR TITLE
chore: add version-bump-reminder agent skill

### DIFF
--- a/.agents/skills/version-bump-reminder/SKILL.md
+++ b/.agents/skills/version-bump-reminder/SKILL.md
@@ -55,13 +55,17 @@ To bump after merge:
 ```sh
 git checkout master && git pull
 make bump_version VERSION=<next>
+```
+
+Then, to trigger the release workflow, push the commit and tag:
+```sh
 git push && git push --tags
 ```
 
-Or if you'd prefer a different bump:
-- Patch: `make bump_version VERSION=<patch>`
-- Minor: `make bump_version VERSION=<minor>`
-- Major: `make bump_version VERSION=<major>`
+Or if you'd prefer a different bump (fill in the computed version number):
+- Patch: `make bump_version VERSION=<computed-patch-version, e.g. 0.2.2>`
+- Minor: `make bump_version VERSION=<computed-minor-version, e.g. 0.3.0>`
+- Major: `make bump_version VERSION=<computed-major-version, e.g. 1.0.0>`
 
 Would you like me to proceed with the [bump type] bump, or do you want a different version?
 


### PR DESCRIPTION
## Summary
- Add `.agents/skills/version-bump-reminder/SKILL.md` — a skill that triggers after pushing a PR to recommend the appropriate semver bump type
- Analyzes PR changes and provides patch/minor/major recommendation with justification

## Test plan
- [ ] Verify skill triggers correctly after PR push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
