### PR TITLE
docs: add OSWorld leaderboard section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install the desktest CLI by running `curl -fsSL https://raw.githubusercontent.co
 
 ## OSWorld Leaderboard
 
-Desktest is based on the agent harness as the [OSWorld](https://os-world.github.io/) benchmark for evaluating multimodal agents on real-world computer tasks. The leaderboard below tracks which models perform best, [updated weekly](https://github.com/Edison-Watch/osworld-leaderboard-updater):
+Desktest uses the same agent harness as the [OSWorld](https://os-world.github.io/) benchmark for evaluating multimodal agents on real-world computer tasks. The leaderboard below tracks which models perform best, [updated weekly](https://github.com/Edison-Watch/osworld-leaderboard-updater):
 
 [![OSWorld Leaderboard](https://raw.githubusercontent.com/Edison-Watch/osworld-leaderboard-updater/main/assets/osworld-leaderboard.svg)](https://github.com/Edison-Watch/osworld-leaderboard-updater)
 


### PR DESCRIPTION
## Summary
- Adds an OSWorld Leaderboard section to the README (after Features, before Use Cases)
- Embeds the weekly-updated leaderboard SVG from Edison-Watch/osworld-leaderboard-updater
- Links to the original OSWorld benchmark project

## Test plan
- [ ] Verify SVG renders correctly on the GitHub PR/repo page
- [ ] Verify clickthrough links work (leaderboard image → updater repo, "OSWorld" → os-world.github.io, "updated weekly" → updater repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/edison-watch/desktest/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
