### PR TITLE
chore: remove dead code in observation and tart modules

### DIFF
--- a/src/observation.rs
+++ b/src/observation.rs
@@ -397,8 +397,8 @@ pub async fn probe_a11y_timing(
 }
 
 /// Save an a11y tree to a file in the artifacts directory.
-#[allow(dead_code)]
-pub async fn save_a11y_tree(
+#[cfg(test)]
+async fn save_a11y_tree(
     artifacts_dir: &Path,
     step_index: usize,
     a11y_text: &str,

--- a/src/tart/mod.rs
+++ b/src/tart/mod.rs
@@ -134,7 +134,6 @@ impl TartSession {
         }
     }
 
-    #[allow(dead_code)] // accessor for future use
     pub fn vm_name(&self) -> &str {
         &self.vm_name
     }


### PR DESCRIPTION
## Summary
- `observation::save_a11y_tree`: gate behind `#[cfg(test)]` since it's only used in tests. The production a11y-saving function lives in `provider/helpers.rs` and remains the active one used by `claude_cli.rs`.
- `TartSession::vm_name`: drop stale `#[allow(dead_code)]` annotation — the method is actively called from `interactive.rs:378-379`. Git history shows the annotation was added ~2 hours before the actual callers were added in commit `0291c6d` and was never cleaned up.

## Background
Came out of a dead-code audit. Three top-priority items were investigated by sub-agents:
1. ✅ `observation::save_a11y_tree` — confirmed dead, fixed here
2. ❌ `TartSession::guest_shared_dir` field/accessor — false positive (intentional architectural symmetry with `WindowsVmSession`); tracked in #125 for later cleanup once wired up
3. ✅ Stale `#[allow(dead_code)]` on `TartSession::vm_name` — confirmed stale, fixed here

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — all 533 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)