### PR TITLE
Add architecture diagram to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install the desktest CLI by running `curl -fsSL https://raw.githubusercontent.co
 ```
 </details>
 
-<img width="727" height="362" alt="Screenshot 2026-04-08 at 21 57 34" src="https://github.com/user-attachments/assets/3c37ff7c-5db7-4959-977e-1c6aee9f6b74" />
+<img src="docs/architecture.svg" alt="How Desktest works" width="690" />
 
 
 ## Getting Started
@@ -349,7 +349,37 @@ Or set the `DESKTEST_SLACK_WEBHOOK_URL` environment variable (takes precedence o
 <details>
 <summary>Expand</summary>
 
-<img src="docs/architecture.svg" alt="How Desktest works" width="690" />
+```
+Developer writes task.json
+        │
+        ▼
+   ┌──────────────┐
+   │ desktest CLI  │  validate / run / suite / interactive
+   └────┬─────────┘
+        │
+        ├─── Linux ──────────────┐  ├─── macOS ─────────────┐  ├─── Windows ────────────┐
+        │  Docker Container      │  │  Tart VM / native host │  │  QEMU/KVM VM           │
+        │  Xvfb + XFCE + x11vnc  │  │  Native macOS desktop  │  │  Windows 11 desktop    │
+        │  PyAutoGUI (X11)       │  │  PyAutoGUI (Quartz)    │  │  PyAutoGUI (Win32)     │
+        │  pyatspi (AT-SPI2)     │  │  a11y-helper (AXUIEl.) │  │  uiautomation (UIA)    │
+        │  scrot (screenshot)    │  │  screencapture         │  │  PIL ImageGrab         │
+        └──────────┬─────────────┘  └──────────┬─────────────┘  └──────────┬─────────────┘
+                   │ screenshot + a11y tree     │                          │
+                   └──────────────┬─────────────┴──────────────────────────┘
+                                  ▼
+                     ┌──────────────────┐
+                     │  LLM Agent Loop  │  observe → think → act → repeat
+                     │  (PyAutoGUI code)│
+                     └────────┬─────────┘
+                              │
+                              ▼
+                     ┌──────────────────┐
+                     │  Evaluator       │  programmatic checks / LLM judge / hybrid
+                     └────────┬─────────┘
+                              │
+                              ▼
+                     results.json + recording.mp4 + trajectory.jsonl
+```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -349,37 +349,7 @@ Or set the `DESKTEST_SLACK_WEBHOOK_URL` environment variable (takes precedence o
 <details>
 <summary>Expand</summary>
 
-```
-Developer writes task.json
-        │
-        ▼
-   ┌──────────────┐
-   │ desktest CLI  │  validate / run / suite / interactive
-   └────┬─────────┘
-        │
-        ├─── Linux ──────────────┐  ├─── macOS ─────────────┐  ├─── Windows ────────────┐
-        │  Docker Container      │  │  Tart VM / native host │  │  QEMU/KVM VM           │
-        │  Xvfb + XFCE + x11vnc  │  │  Native macOS desktop  │  │  Windows 11 desktop    │
-        │  PyAutoGUI (X11)       │  │  PyAutoGUI (Quartz)    │  │  PyAutoGUI (Win32)     │
-        │  pyatspi (AT-SPI2)     │  │  a11y-helper (AXUIEl.) │  │  uiautomation (UIA)    │
-        │  scrot (screenshot)    │  │  screencapture         │  │  PIL ImageGrab         │
-        └──────────┬─────────────┘  └──────────┬─────────────┘  └──────────┬─────────────┘
-                   │ screenshot + a11y tree     │                          │
-                   └──────────────┬─────────────┴──────────────────────────┘
-                                  ▼
-                     ┌──────────────────┐
-                     │  LLM Agent Loop  │  observe → think → act → repeat
-                     │  (PyAutoGUI code)│
-                     └────────┬─────────┘
-                              │
-                              ▼
-                     ┌──────────────────┐
-                     │  Evaluator       │  programmatic checks / LLM judge / hybrid
-                     └────────┬─────────┘
-                              │
-                              ▼
-                     results.json + recording.mp4 + trajectory.jsonl
-```
+<img src="docs/architecture.svg" alt="How Desktest works" width="690" />
 
 </details>
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,114 @@
+<svg width="100%" viewBox="0 0 690 490" xmlns="http://www.w3.org/2000/svg" font-family="Inter, Helvetica, Arial, sans-serif" style="">
+<defs>
+<marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+<path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</marker>
+<symbol id="ic-cli" viewBox="0 0 24 24">
+<rect x="3" y="5" width="18" height="14" rx="1" fill="none" stroke="#C3FFFD" stroke-width="1.4"/>
+<path d="M7 10 L 10 12 L 7 14" fill="none" stroke="#C3FFFD" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="12" y1="14" x2="17" y2="14" stroke="#C3FFFD" stroke-width="1.4" stroke-linecap="round"/>
+</symbol>
+<symbol id="ic-app" viewBox="0 0 24 24">
+<rect x="3" y="4" width="18" height="14" rx="1" fill="none" stroke="#C3FFFD" stroke-width="1.4"/>
+<line x1="3" y1="8" x2="21" y2="8" stroke="#C3FFFD" stroke-width="1.4"/>
+<circle cx="5.5" cy="6" r="0.7" fill="#C3FFFD"/>
+<circle cx="7.7" cy="6" r="0.7" fill="#C3FFFD"/>
+<circle cx="9.9" cy="6" r="0.7" fill="#C3FFFD"/>
+<rect x="6" y="11" width="6" height="4" fill="#C3FFFD" opacity="0.4"/>
+<line x1="14" y1="11.5" x2="18" y2="11.5" stroke="#C3FFFD" stroke-width="1.2"/>
+<line x1="14" y1="14" x2="18" y2="14" stroke="#C3FFFD" stroke-width="1.2"/>
+</symbol>
+
+<!-- Pointer cursor (classic OS arrow) -->
+<symbol id="ic-cursor" viewBox="0 0 24 24">
+<path d="M5 3 L 5 18 L 9 14.5 L 11.5 20 L 14 19 L 11.5 13.5 L 17 13 Z" fill="#C3FFFD" stroke="#000000" stroke-width="0.8" stroke-linejoin="round"/>
+</symbol>
+
+<symbol id="ic-camera" viewBox="0 0 24 24">
+<path d="M3 8 h3 l1.5 -2 h6 l1.5 2 h3 a1 1 0 0 1 1 1 v9 a1 1 0 0 1 -1 1 H3 a1 1 0 0 1 -1 -1 V9 a1 1 0 0 1 1 -1 z" fill="none" stroke="#C3FFFD" stroke-width="1.3" stroke-linejoin="round"/>
+<circle cx="12" cy="13" r="3.5" fill="none" stroke="#C3FFFD" stroke-width="1.3"/>
+<circle cx="12" cy="13" r="1.2" fill="#C3FFFD"/>
+<rect x="17.5" y="9.5" width="2" height="1.2" fill="#C3FFFD"/>
+</symbol>
+<symbol id="ic-code" viewBox="0 0 24 24">
+<path d="M8 6 L 3 12 L 8 18" fill="none" stroke="#C3FFFD" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 6 L 21 12 L 16 18" fill="none" stroke="#C3FFFD" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+<line x1="13.5" y1="5" x2="10.5" y2="19" stroke="#C3FFFD" stroke-width="1.4" stroke-linecap="round"/>
+</symbol>
+<symbol id="ic-robot" viewBox="0 0 256 256">
+<circle cx="128" cy="24" r="10" fill="none" stroke="#C3FFFD" stroke-width="6"/>
+<rect x="125" y="34" width="6" height="20" fill="#C3FFFD"/>
+<path fill="#C3FFFD" d="M40,144a88,88,0,0,1,176,0v44a44,44,0,0,1-44,44H84a44,44,0,0,1-44-44Z"/>
+<rect x="64" y="116" width="128" height="80" rx="28" fill="#000000"/>
+<rect x="88" y="138" width="24" height="36" rx="12" fill="#C3FFFD"/>
+<rect x="144" y="138" width="24" height="36" rx="12" fill="#C3FFFD"/>
+</symbol>
+<symbol id="ic-stack" viewBox="0 0 24 24">
+<path d="M12 3 L 21 8 L 12 13 L 3 8 Z" fill="none" stroke="#C3FFFD" stroke-width="1.4" stroke-linejoin="round"/>
+<path d="M3 12 L 12 17 L 21 12" fill="none" stroke="#C3FFFD" stroke-width="1.4" stroke-linejoin="round"/>
+<path d="M3 16 L 12 21 L 21 16" fill="none" stroke="#C3FFFD" stroke-width="1.4" stroke-linejoin="round"/>
+</symbol>
+<symbol id="ic-docker" viewBox="0 0 24 24">
+<path fill="#008fe2" d="M13.98 11.08h2.12a.19.19 0 0 0 .19-.19V9.01a.19.19 0 0 0-.19-.19h-2.12a.18.18 0 0 0-.18.18v1.9c0 .1.08.18.18.18m-2.95-5.43h2.12a.19.19 0 0 0 .18-.19V3.57a.19.19 0 0 0-.18-.18h-2.12a.18.18 0 0 0-.19.18v1.9c0 .1.09.18.19.18m0 2.71h2.12a.19.19 0 0 0 .18-.18V6.29a.19.19 0 0 0-.18-.18h-2.12a.18.18 0 0 0-.19.18v1.89c0 .1.09.18.19.18m-2.93 0h2.12a.19.19 0 0 0 .18-.18V6.29a.18.18 0 0 0-.18-.18H8.1a.18.18 0 0 0-.18.18v1.89c0 .1.08.18.18.18m-2.96 0h2.11a.19.19 0 0 0 .19-.18V6.29a.18.18 0 0 0-.19-.18H5.14a.19.19 0 0 0-.19.18v1.89c0 .1.08.18.19.18m5.89 2.72h2.12a.19.19 0 0 0 .18-.19V9.01a.19.19 0 0 0-.18-.19h-2.12a.18.18 0 0 0-.19.18v1.9c0 .1.09.18.19.18m-2.93 0h2.12a.18.18 0 0 0 .18-.19V9.01a.18.18 0 0 0-.18-.19H8.1a.18.18 0 0 0-.18.18v1.9c0 .1.08.18.18.18m-2.96 0h2.11a.18.18 0 0 0 .19-.19V9.01a.18.18 0 0 0-.18-.19H5.14a.19.19 0 0 0-.19.19v1.88c0 .1.08.19.19.19m-2.92 0h2.12a.18.18 0 0 0 .18-.19V9.01a.18.18 0 0 0-.18-.19H2.22a.18.18 0 0 0-.19.18v1.9c0 .1.08.18.19.18m21.54-1.19c-.06-.05-.67-.51-1.95-.51-.34 0-.68.03-1.01.09a3.77 3.77 0 0 0-1.72-2.57l-.34-.2-.23.33a4.6 4.6 0 0 0-.6 1.43c-.24.97-.1 1.88.4 2.66a4.7 4.7 0 0 1-1.75.42H.76a.75.75 0 0 0-.76.75 11.38 11.38 0 0 0 .7 4.06 6.03 6.03 0 0 0 2.4 3.12c1.18.73 3.1 1.14 5.28 1.14.98 0 1.96-.08 2.93-.26a12.25 12.25 0 0 0 3.82-1.4 10.5 10.5 0 0 0 2.61-2.13c1.25-1.42 2-3 2.55-4.4h.23c1.37 0 2.21-.55 2.68-1 .3-.3.55-.66.7-1.06l.1-.28Z"/>
+</symbol>
+<symbol id="ic-apple" viewBox="0 0 814 1000" preserveAspectRatio="xMidYMid meet">
+<path fill="#FFFFFF" d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/>
+</symbol>
+<symbol id="ic-windows" viewBox="0 0 88 88">
+<path fill="#00adef" d="m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z"/>
+</symbol>
+</defs>
+<rect x="0" y="0" width="680" height="480" fill="#000000" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<rect x="40" y="40" width="520" height="80" fill="none" stroke="#C3FFFD" stroke-width="1.5" style="fill:none;stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1.5px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<rect x="41" y="41" width="208" height="8" fill="#C3FFFD" style="fill:rgb(195, 255, 253);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<text x="64" y="82" fill="#FFFFFF" font-size="22" font-weight="500" letter-spacing="-0.4" style="fill:rgb(255, 255, 255);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:22px;font-weight:500;text-anchor:start;dominant-baseline:auto">How Desktest works</text>
+<text x="64" y="104" fill="#9BA4A6" font-size="12" style="fill:rgb(155, 164, 166);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:12px;font-weight:400;text-anchor:start;dominant-baseline:auto">LLM-powered desktop app testing</text>
+<rect x="160" y="160" width="460" height="200" fill="none" stroke="#C3FFFD" stroke-width="1" stroke-dasharray="5 4" style="fill:none;stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-dasharray:5px, 4px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<text x="170" y="180" fill="#9BA4A6" font-size="10" letter-spacing="1" style="fill:rgb(155, 164, 166);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:10px;font-weight:400;text-anchor:start;dominant-baseline:auto">VIRTUALIZED ENV  //</text>
+<use href="#ic-docker" x="287" y="168" width="14" height="14" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<use href="#ic-apple" x="307" y="168" width="14" height="14" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<use href="#ic-windows" x="327" y="168" width="14" height="14" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<g style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto">
+<rect x="40" y="200" width="100" height="90" fill="none" stroke="#C3FFFD" stroke-width="1" style="fill:none;stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<use href="#ic-cli" x="78" y="218" width="24" height="24" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<text x="90" y="258" fill="#FFFFFF" font-size="12" font-weight="500" text-anchor="middle" style="fill:rgb(255, 255, 255);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:12px;font-weight:500;text-anchor:middle;dominant-baseline:auto">DESKTEST CLI</text>
+<text x="90" y="274" fill="#9BA4A6" font-size="10" text-anchor="middle" style="fill:rgb(155, 164, 166);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:10px;font-weight:400;text-anchor:middle;dominant-baseline:auto">task json · run</text>
+</g>
+<g style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto">
+<rect x="180" y="200" width="120" height="90" fill="none" stroke="#C3FFFD" stroke-width="1" style="fill:none;stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<use href="#ic-app" x="216" y="218" width="24" height="24" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<use href="#ic-cursor" x="252" y="226" width="18" height="18" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<text x="240" y="258" fill="#FFFFFF" font-size="12" font-weight="500" text-anchor="middle" style="fill:rgb(255, 255, 255);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:12px;font-weight:500;text-anchor:middle;dominant-baseline:auto">DESKTOP APP</text>
+<text x="240" y="274" fill="#9BA4A6" font-size="10" text-anchor="middle" style="fill:rgb(155, 164, 166);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:10px;font-weight:400;text-anchor:middle;dominant-baseline:auto">app under test</text>
+</g>
+<g style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto">
+<rect x="320" y="200" width="140" height="40" fill="none" stroke="#C3FFFD" stroke-width="1" style="fill:none;stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<use href="#ic-camera" x="330" y="212" width="16" height="16" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<text x="352" y="225" fill="#FFFFFF" font-size="10" font-weight="500" style="fill:rgb(255, 255, 255);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:10px;font-weight:500;text-anchor:start;dominant-baseline:auto">SCREENSHOT + A11Y</text>
+</g>
+<g style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto">
+<rect x="320" y="250" width="140" height="40" fill="none" stroke="#C3FFFD" stroke-width="1" style="fill:none;stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<use href="#ic-code" x="330" y="262" width="16" height="16" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<text x="352" y="275" fill="#FFFFFF" font-size="10" font-weight="500" style="fill:rgb(255, 255, 255);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:10px;font-weight:500;text-anchor:start;dominant-baseline:auto">PYAUTOGUI</text>
+</g>
+<g style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto">
+<rect x="480" y="200" width="120" height="120" fill="none" stroke="#C3FFFD" stroke-width="1.5" style="fill:none;stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1.5px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<use href="#ic-robot" x="510" y="216" width="60" height="60" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<text x="540" y="300" fill="#FFFFFF" font-size="12" font-weight="500" text-anchor="middle" style="fill:rgb(255, 255, 255);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:12px;font-weight:500;text-anchor:middle;dominant-baseline:auto">LLM AGENT</text>
+</g>
+<g style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto">
+<rect x="540" y="390" width="100" height="80" fill="none" stroke="#C3FFFD" stroke-width="1" style="fill:none;stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<use href="#ic-stack" x="578" y="406" width="20" height="20" style="fill:rgb(0, 0, 0);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<text x="590" y="444" fill="#FFFFFF" font-size="11" font-weight="500" text-anchor="middle" style="fill:rgb(255, 255, 255);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:11px;font-weight:500;text-anchor:middle;dominant-baseline:auto">ARTIFACTS</text>
+<text x="590" y="458" fill="#9BA4A6" font-size="9" text-anchor="middle" style="fill:rgb(155, 164, 166);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:9px;font-weight:400;text-anchor:middle;dominant-baseline:auto">screenshots, logs, traces</text>
+</g>
+<line x1="140" y1="245" x2="178" y2="245" stroke="#C3FFFD" stroke-width="1" marker-end="url(#arrow)" style="fill:rgb(0, 0, 0);stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<line x1="300" y1="220" x2="318" y2="220" stroke="#C3FFFD" stroke-width="1" marker-end="url(#arrow)" style="fill:rgb(0, 0, 0);stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<line x1="460" y1="220" x2="478" y2="220" stroke="#C3FFFD" stroke-width="1" marker-end="url(#arrow)" style="fill:rgb(0, 0, 0);stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<line x1="478" y1="270" x2="462" y2="270" stroke="#C3FFFD" stroke-width="1" marker-end="url(#arrow)" style="fill:rgb(0, 0, 0);stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<line x1="320" y1="270" x2="302" y2="270" stroke="#C3FFFD" stroke-width="1" marker-end="url(#arrow)" style="fill:rgb(0, 0, 0);stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<text x="384" y="192" fill="#C3FFFD" font-size="10" font-style="italic" text-anchor="middle" style="fill:rgb(195, 255, 253);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:10px;font-weight:400;font-style:italic;text-anchor:middle;dominant-baseline:auto">observe →</text>
+<text x="384" y="306" fill="#C3FFFD" font-size="10" font-style="italic" text-anchor="middle" style="fill:rgb(195, 255, 253);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:10px;font-weight:400;font-style:italic;text-anchor:middle;dominant-baseline:auto">← act</text>
+<line x1="590" y1="360" x2="590" y2="388" stroke="#C3FFFD" stroke-width="1" marker-end="url(#arrow)" style="fill:rgb(0, 0, 0);stroke:rgb(195, 255, 253);color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;text-anchor:start;dominant-baseline:auto"/>
+<text x="600" y="378" fill="#9BA4A6" font-size="10" font-style="italic" style="fill:rgb(155, 164, 166);stroke:none;color:rgb(255, 255, 255);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;opacity:1;font-family:Inter, Helvetica, Arial, sans-serif;font-size:10px;font-weight:400;font-style:italic;text-anchor:start;dominant-baseline:auto">writes</text>
+</svg>


### PR DESCRIPTION
## Summary
Added a visual architecture diagram to the documentation that illustrates how Desktest works, replacing a static screenshot with an interactive SVG diagram.

## Changes
- **Added `docs/architecture.svg`**: A comprehensive SVG diagram showing the Desktest architecture with:
  - CLI component for task execution
  - Desktop app under test with screenshot and accessibility capture
  - PyAutoGUI for automation control
  - LLM Agent as the core decision-making component
  - Artifacts output (screenshots, logs, traces)
  - Visual flow showing the observe-act loop between components
  - Support for virtualized environments (Docker, macOS, Windows)

- **Updated `README.md`**: Replaced the embedded screenshot image with a reference to the new SVG diagram, improving maintainability and providing a clearer visual representation of the system architecture

## Implementation Details
The SVG diagram uses:
- Custom icon symbols for different components (CLI, app, camera, code, robot, stack)
- Color-coded elements with cyan (#C3FFFD) accents on dark background
- Directional arrows showing data flow and interactions
- Labeled sections for clarity and understanding of the testing workflow

https://claude.ai/code/session_01SwbTLdCG4w9TE5XAJrfZux

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an interactive architecture diagram (`docs/architecture.svg`) and update `README.md` to use it instead of the screenshot. The diagram outlines the CLI, app under test, capture/automation, LLM agent, artifacts, and the observe–act loop, with Docker/macOS/Windows support.

<sup>Written for commit bd7ed12de6ab8023b487255ef093116c71ff1d1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

