### PR TITLE
Enforce MacosNative app config validation with pattern matching

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -1140,15 +1140,13 @@ fn validate_app_config(app: &AppConfig) -> Result<(), AppError> {
             }
         }
         AppConfig::MacosNative {
-            bundle_id,
-            app_path,
+            bundle_id: None,
+            app_path: None,
         } => {
-            if bundle_id.is_none() && app_path.is_none() {
-                return Err(AppError::Config(
-                    "MacosNative app: at least one of 'bundle_id' or 'app_path' must be specified."
-                        .into(),
-                ));
-            }
+            return Err(AppError::Config(
+                "MacosNative app: at least one of 'bundle_id' or 'app_path' must be specified."
+                    .into(),
+            ));
         }
         AppConfig::DockerImage { image, digest, .. } => {
             if image.is_empty() {


### PR DESCRIPTION
## Summary
Refactored the MacosNative app configuration validation to use exhaustive pattern matching instead of runtime checks, making invalid configurations impossible to construct.

## Key Changes
- Modified the `validate_app_config` function to pattern match on `MacosNative { bundle_id: None, app_path: None }` directly
- Removed the conditional `if bundle_id.is_none() && app_path.is_none()` check
- Now the validation error is returned unconditionally when both fields are `None`, as this is the only case the pattern matches

## Implementation Details
This change leverages Rust's pattern matching to make the validation more explicit and type-safe. By matching on the specific case where both `bundle_id` and `app_path` are `None`, the code makes it clear that this is an invalid configuration state. The error is now returned directly rather than being conditional, improving code clarity and reducing the possibility of logic errors.

https://claude.ai/code/session_01JeA7bssA8UsoiQXhRBxGnV

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors MacosNative app config validation to match on the exact invalid state (both bundle_id and app_path are None) and return the error directly. Removes the inner conditional, keeps behavior the same (still requires at least one value), and satisfies clippy::collapsible_match.

<sup>Written for commit 23a47322fe284dad64e7d4ec7ed4c995057a8b84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

